### PR TITLE
Refine dev experience theme for Streamlit app

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@
 import streamlit as st
 from pathlib import Path
 
-st.set_page_config(page_title="CCA Senior Navigator", layout="centered")
+st.set_page_config(page_title="CCA Senior Navigator", layout="wide")
 
 # ========= Global CSS (single source of truth) =========
 def _inject_global_css():

--- a/pages/welcome.py
+++ b/pages/welcome.py
@@ -82,6 +82,33 @@ st.markdown(
 
       /* Safety: hide truly empty markdown containers */
       div[data-testid="stMarkdownContainer"]:empty{ display:none !important; }
+
+      .pro-callout{
+        margin-top: 2.25rem;
+        padding: 1.5rem 1.75rem;
+        border-radius: 16px;
+        background: linear-gradient(135deg, rgba(15, 60, 90, 0.06), rgba(15, 60, 90, 0.02));
+        border: 1px solid rgba(10, 40, 60, 0.08);
+      }
+      .pro-callout-title{
+        font-size: 0.9rem;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: rgba(10, 40, 60, 0.75);
+        margin-bottom: 0.35rem;
+      }
+      .pro-callout-body{
+        font-size: 0.95rem;
+        line-height: 1.5;
+        color: rgba(20, 20, 20, 0.78);
+        margin-bottom: 0.9rem;
+      }
+      .pro-callout-roles{
+        font-size: 0.9rem;
+        color: rgba(10, 40, 60, 0.7);
+        margin-bottom: 1rem;
+      }
     </style>
     """,
     unsafe_allow_html=True,
@@ -200,3 +227,23 @@ with col2:
         "For myself",
         "pages/tell_us_about_you.py",
     )
+
+st.markdown(
+    """
+    <div class="pro-callout">
+      <div class="pro-callout-title">For Professionals</div>
+      <div class="pro-callout-body">
+        We also support teams guiding older adults through transitions. Access a quieter workspace built for coordinating services with families.
+      </div>
+      <div class="pro-callout-roles">
+        Discharge planners &middot; Referral partners
+      </div>
+    </div>
+    """,
+    unsafe_allow_html=True,
+)
+
+_, cta_right = st.columns([2, 1])
+with cta_right:
+    if st.button("Professional Mode", key="pro_mode_cta"):
+        st.switch_page("pages/professional_mode.py")

--- a/static/style.css
+++ b/static/style.css
@@ -1,77 +1,386 @@
-/* Senior Care Navigator CSS - Optimized for Streamlit Cloud */
+/* Senior Care Navigator — Dev Experience Theme */
+/* Reworked visual system optimized for the development environment */
 
-/* === CSS Variables === */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Plus+Jakarta+Sans:wght@600;700&display=swap');
+
+/* === Design Tokens === */
 :root {
+  --font-base: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-display: "Plus Jakarta Sans", var(--font-base);
+
+  --app-gradient: radial-gradient(circle at 12% 18%, rgba(99, 102, 241, 0.14) 0, rgba(99, 102, 241, 0) 55%),
+                   radial-gradient(circle at 88% 12%, rgba(14, 165, 233, 0.12) 0, rgba(14, 165, 233, 0) 52%),
+                   linear-gradient(160deg, #eef2ff 0%, #f8faff 48%, #e0e7ff 100%);
+
+  --ink-900: #0f172a;
+  --ink-700: #1e293b;
+  --ink-500: #475569;
+  --ink-300: #94a3b8;
+
+  --surface-elevated: rgba(255, 255, 255, 0.96);
+  --surface-muted: rgba(248, 250, 255, 0.68);
+  --surface-border: rgba(148, 163, 184, 0.18);
+  --shadow-lg: 0 24px 60px -34px rgba(15, 23, 42, 0.6);
+  --shadow-md: 0 16px 42px -28px rgba(30, 41, 59, 0.48);
+  --shadow-sm: 0 12px 30px -24px rgba(30, 41, 59, 0.45);
+
+  --radius-md: 18px;
+  --radius-lg: 28px;
+
+  --ring-focus: 0 0 0 4px rgba(99, 102, 241, 0.24);
+
   /* Pill (Chip) Styles */
-  --pill-radius: 14px;
-  --pill-pad: 0.70rem 1rem;
-  --pill-gap: 0.75rem;
-  --pill-text: #111827;
-  --pill-bg: #F3F4F6;
-  --pill-brd: #E5E7EB;
-  --pill-hover: #E9EBF0;
-  --pill-selected: #111827;
-  --pill-selected-hover: #000000;
-  --pill-shadow: 0 2px 6px rgba(17, 24, 39, 0.08);
+  --pill-radius: 16px;
+  --pill-pad: 0.75rem 1.15rem;
+  --pill-gap: 0.85rem;
+  --pill-text: #1f2937;
+  --pill-bg: rgba(255, 255, 255, 0.9);
+  --pill-brd: rgba(99, 102, 241, 0.26);
+  --pill-hover: rgba(99, 102, 241, 0.12);
+  --pill-selected: #3730a3;
+  --pill-selected-hover: #1e1b4b;
+  --pill-shadow: 0 18px 32px -26px rgba(30, 41, 59, 0.66);
   --pill-font: 16px;
 
   /* Button Styles */
-  --btn-primary: #2E6EFF;
-  --btn-primary-hover: #1F5AE6;
-  --btn-secondary-bg: #EAF2FF;
-  --btn-secondary-text: #2E6EFF;
-  --btn-secondary-brd: #D6E4FF;
+  --btn-primary: #4f46e5;
+  --btn-primary-hover: #4338ca;
+  --btn-secondary-bg: rgba(79, 70, 229, 0.12);
+  --btn-secondary-text: #3730a3;
+  --btn-secondary-brd: rgba(79, 70, 229, 0.32);
+
+  --badge-bg: rgba(79, 70, 229, 0.12);
+  --badge-text: #3730a3;
+}
+
+/* === App Chrome === */
+body, .stApp, [data-testid="stAppViewContainer"] {
+  font-family: var(--font-base);
+  color: var(--ink-900);
+  background: transparent;
+}
+
+.stApp {
+  background: var(--app-gradient);
+  background-attachment: fixed;
+}
+
+[data-testid="stAppViewContainer"] {
+  background: transparent;
+  min-height: 100vh;
+}
+
+[data-testid="stAppViewContainer"] > .main {
+  padding-top: 3.6rem;
+  padding-bottom: 4rem;
+}
+
+[data-testid="stHeader"] {
+  background: transparent;
+  backdrop-filter: none;
+  border-bottom: none;
+}
+
+[data-testid="stToolbar"] {
+  background: transparent;
+}
+
+.block-container {
+  background: var(--surface-elevated);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-lg);
+  padding: 3rem clamp(1.4rem, 4vw, 3.4rem) 3.5rem;
+  max-width: 1140px;
+  margin: 0 auto;
+  backdrop-filter: blur(16px);
+}
+
+@media (max-width: 1200px) {
+  .block-container {
+    margin: 0 1.75rem;
+  }
+}
+
+@media (max-width: 768px) {
+  [data-testid="stAppViewContainer"] > .main {
+    padding-top: 2.6rem;
+    padding-bottom: 3rem;
+  }
+  .block-container {
+    margin: 0 1.1rem;
+    padding: 2.25rem 1.4rem 2.6rem;
+    border-radius: 22px;
+  }
+}
+
+@media (max-width: 540px) {
+  .block-container {
+    margin: 0 0.65rem;
+    padding: 1.75rem 1.05rem 2.2rem;
+    border-radius: 18px;
+  }
+}
+
+/* Sidebar refinement */
+[data-testid="stSidebar"] {
+  background: rgba(15, 23, 42, 0.9);
+  backdrop-filter: blur(12px);
+  border-right: 1px solid rgba(148, 163, 184, 0.18);
+  color: #f8fafc;
+}
+
+[data-testid="stSidebar"] h1,
+[data-testid="stSidebar"] h2,
+[data-testid="stSidebar"] h3,
+[data-testid="stSidebar"] h4,
+[data-testid="stSidebar"] p,
+[data-testid="stSidebar"] span,
+[data-testid="stSidebar"] label {
+  color: #e0e7ff !important;
+}
+
+[data-testid="stSidebar"] .stButton > button {
+  background: rgba(248, 250, 255, 0.14);
+  border-radius: 14px;
+  color: #e0e7ff;
+  border: 1px solid rgba(248, 250, 255, 0.18);
+}
+
+[data-testid="stSidebar"] .stButton > button:hover {
+  background: rgba(248, 250, 255, 0.24);
+  color: #ffffff;
+}
+
+[data-testid="stSidebar"] .stMarkdown a {
+  color: #c7d2fe;
 }
 
 /* === Typography === */
+h1, h2, h3, h4 {
+  font-family: var(--font-display);
+  color: var(--ink-900);
+  letter-spacing: -0.3px;
+}
+
 h1 {
-  letter-spacing: 0.2px;
+  font-size: clamp(32px, 4vw, 44px);
+  font-weight: 700;
+  margin-bottom: 0.85rem;
+}
+
+h2 {
+  font-size: clamp(24px, 3vw, 32px);
+  font-weight: 600;
+  margin-top: 2.1rem;
+  margin-bottom: 0.65rem;
+}
+
+h3 {
+  font-size: clamp(20px, 2.6vw, 26px);
+  font-weight: 600;
+  margin-top: 1.8rem;
+  margin-bottom: 0.45rem;
+}
+
+h4 {
+  font-size: clamp(18px, 2.2vw, 22px);
+  font-weight: 600;
+  margin-top: 1.4rem;
+  margin-bottom: 0.35rem;
+}
+
+p, .stMarkdown li, .stMarkdown span {
+  color: var(--ink-500);
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+strong {
+  color: var(--ink-700);
+}
+
+a {
+  color: var(--btn-primary);
+  text-decoration: none;
   font-weight: 600;
 }
 
-.scn-hero {
-  text-align: center;
-  max-width: 820px;
-  margin: 0 auto 1.25rem;
-  padding: 1rem 0;
-  /* Comment: Hero section - keep this centered */
+a:hover {
+  text-decoration: underline;
 }
 
-.scn-hero h2 {
-  margin: 0.25rem 0 0.35rem;
+.stCaption, .stMarkdown caption {
+  color: var(--ink-300) !important;
 }
 
-.scn-hero p {
-  margin: 0.25rem auto 0;
-  max-width: 720px;
-  color: #374151;
+code, pre {
+  font-family: "JetBrains Mono", "SFMono-Regular", Menlo, Monaco, Consolas, monospace;
+  background: rgba(15, 23, 42, 0.06);
+  border-radius: 10px;
+  padding: 0.15rem 0.35rem;
+  color: #111827;
 }
 
-/* === Progress Rail === */
-.progress-rail {
-  display: flex;
-  gap: 0.5rem;
-  margin: 0.25rem 0 1rem;
-  /* Comment: Progress bar - adjust segments here */
+hr, .section-divider {
+  border: none;
+  border-top: 1px solid rgba(148, 163, 184, 0.22);
+  margin: 2.4rem 0 1.8rem;
 }
 
-.progress-rail .seg {
-  height: 4px;
-  flex: 1;
-  border-radius: 999px;
-  background: #E5E7EB;
+/* === Containers & Cards === */
+.stContainer, .stTabs, [data-testid="stVerticalBlockBorderWrapper"] {
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: var(--shadow-sm);
 }
 
-.progress-rail .seg.active {
+.stExpander {
+  border-radius: var(--radius-md) !important;
+  border: 1px solid rgba(148, 163, 184, 0.24) !important;
+  background: rgba(255, 255, 255, 0.9) !important;
+}
+
+.stExpander > div:first-child {
+  border-radius: var(--radius-md) !important;
+}
+
+.stAlert {
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  background: rgba(219, 234, 254, 0.55);
+  color: #1d4ed8;
+}
+
+.stAlert[data-baseweb="notification"] svg {
+  filter: drop-shadow(0 4px 8px rgba(37, 99, 235, 0.18));
+}
+
+.stMetric {
+  background: rgba(79, 70, 229, 0.08);
+  border-radius: 16px;
+  padding: 0.95rem 1.25rem;
+}
+
+/* Streamlit bordered containers re-imagined as cards */
+div[style*="border: 1px solid #e0e0e0"] {
+  padding: 1.8rem 1.5rem;
+  margin: 0 auto;
+  max-width: 360px;
+  border-radius: 20px !important;
+  border: 1px solid rgba(148, 163, 184, 0.18) !important;
+  background: rgba(255, 255, 255, 0.92) !important;
+  box-shadow: var(--shadow-sm) !important;
+}
+
+div[style*="min-height: 250px"] {
+  min-height: 260px;
+}
+
+/* === Buttons === */
+.stButton > button {
+  padding: 0.78rem 1.3rem;
+  border-radius: 14px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: transform 0.14s ease, box-shadow 0.14s ease, background 0.14s ease;
+  box-shadow: var(--shadow-sm);
+}
+
+.stButton > button:hover {
+  transform: translateY(-1px);
+}
+
+.stButton > button:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-sm), var(--ring-focus);
+}
+
+button[kind="primary"] {
   background: var(--btn-primary);
+  color: #ffffff;
+  border: none;
+}
+
+button[kind="primary"]:hover {
+  background: var(--btn-primary-hover);
+}
+
+button[kind="secondary"] {
+  background: var(--btn-secondary-bg);
+  color: var(--btn-secondary-text);
+  border: 1px solid var(--btn-secondary-brd);
+  box-shadow: none;
+}
+
+button[kind="secondary"]:hover {
+  background: rgba(79, 70, 229, 0.22);
+}
+
+.scn-nav-row {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: nowrap;
+  margin: 0.5rem 0 0.85rem;
+}
+
+.scn-nav-row > div {
+  flex: 0 0 auto;
+}
+
+/* === Inputs & Form Controls === */
+.stTextInput > div > input,
+.stNumberInput > div > input,
+.stSelectbox > div > div,
+.stMultiSelect > div > div,
+.stDateInput > div > div input,
+.stTimeInput > div > div input,
+.stTextArea textarea {
+  border-radius: 14px !important;
+  border: 1.5px solid rgba(148, 163, 184, 0.38) !important;
+  padding: 0.65rem 0.85rem !important;
+  background: rgba(255, 255, 255, 0.94) !important;
+  transition: border 0.15s ease, box-shadow 0.15s ease;
+  color: var(--ink-700) !important;
+}
+
+.stTextInput > div > input:focus,
+.stNumberInput > div > input:focus,
+.stSelectbox > div > div:focus,
+.stMultiSelect > div > div:focus,
+.stDateInput > div > div input:focus,
+.stTimeInput > div > div input:focus,
+.stTextArea textarea:focus {
+  border-color: rgba(79, 70, 229, 0.75) !important;
+  box-shadow: 0 0 0 4px rgba(79, 70, 229, 0.16) !important;
+}
+
+.stTextArea textarea {
+  min-height: 140px;
+}
+
+.stSelectbox [data-baseweb="input"] > div {
+  padding: 0;
+}
+
+.stCheckbox > label {
+  color: var(--ink-700);
+  font-weight: 500;
+}
+
+.stCheckbox > label:hover {
+  color: var(--btn-primary);
 }
 
 /* === Radio Chips (Streamlit Radio Override) === */
 .stRadio > div > label {
   font-size: 1.05rem;
   font-weight: 600;
-  color: #111827;
-  margin-bottom: 0.5rem;
+  color: var(--ink-700);
+  margin-bottom: 0.6rem;
 }
 
 .stRadio [role="radiogroup"] {
@@ -80,8 +389,7 @@ h1 {
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   max-width: 960px;
   margin: 0 auto;
-  padding: 0.5rem 0;
-  /* Comment: Radio group - keep columns clean */
+  padding: 0.65rem 0;
 }
 
 .stRadio [role="radiogroup"] > label {
@@ -92,7 +400,7 @@ h1 {
 }
 
 .stRadio [role="radiogroup"] > label > div:first-child {
-  display: none; /* Hide default radio dot */
+  display: none;
 }
 
 .stRadio [role="radiogroup"] input[type="radio"] {
@@ -122,7 +430,7 @@ h1 {
   user-select: none;
   text-align: center;
   font-weight: 600;
-  min-height: 56px;
+  min-height: 64px;
 }
 
 .stRadio [role="radiogroup"] > label > div:last-child:hover {
@@ -132,9 +440,9 @@ h1 {
 .stRadio [role="radiogroup"] > label:has(input[type="radio"]:checked) > div:last-child,
 .stRadio [role="radiogroup"] [role="radio"][aria-checked="true"] > div:last-child {
   background: var(--pill-selected);
-  color: #FFFFFF;
+  color: #ffffff;
   border-color: var(--pill-selected);
-  box-shadow: 0 3px 12px rgba(17, 24, 39, 0.25);
+  box-shadow: 0 22px 44px -30px rgba(49, 46, 129, 0.65);
   font-weight: 700;
 }
 
@@ -143,76 +451,136 @@ h1 {
   background: var(--pill-selected-hover);
 }
 
-/* === Navigation Buttons === */
-.scn-nav-row {
+/* === Tabs & Pills === */
+.stTabs [data-baseweb="tab-list"] {
+  border-bottom: 1px solid rgba(148, 163, 184, 0.28);
+  gap: 0.35rem;
+}
+
+.stTabs [data-baseweb="tab"] {
+  background: transparent;
+  border-radius: 14px 14px 0 0;
+  padding: 0.75rem 1.1rem;
+  font-weight: 600;
+  color: var(--ink-500);
+}
+
+.stTabs [aria-selected="true"] {
+  background: rgba(79, 70, 229, 0.12);
+  color: var(--btn-primary);
+  border-bottom: 3px solid var(--btn-primary);
+}
+
+/* === Progress Rail === */
+.progress-rail {
   display: flex;
-  gap: 12px;
-  justify-content: center;
-  align-items: center;
-  flex-wrap: nowrap;
-  margin: 0.5rem 0 0.75rem;
-  /* Comment: Nav row - keep buttons balanced */
+  gap: 0.55rem;
+  margin: 0.25rem 0 1rem;
 }
 
-.scn-nav-row > div {
-  flex: 0 0 auto;
+.progress-rail .seg {
+  height: 4px;
+  flex: 1;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.3);
 }
 
-.stButton > button {
-  padding: 0.7rem 1.1rem;
-  border-radius: 12px;
-  min-width: 120px;
-  margin: 0 auto;
-  /* Comment: Button - ensure consistent size */
-}
-
-button[kind="primary"] {
+.progress-rail .seg.active {
   background: var(--btn-primary);
-  color: #FFFFFF;
-  border: 0;
-  box-shadow: 0 2px 8px rgba(46, 110, 255, 0.25);
 }
 
-button[kind="primary"]:hover {
-  background: var(--btn-primary-hover);
+/* === Layout Helpers === */
+div[style*="grid-template-columns"] {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
 }
 
-button[kind="secondary"] {
-  background: var(--btn-secondary-bg);
-  color: var(--btn-secondary-text);
-  border: 1px solid var(--btn-secondary-brd);
+div[style*="display: flex"] {
+  justify-content: center;
+  gap: 2rem;
 }
 
-button[kind="secondary"]:hover {
-  background: #D6E4FF;
+/* === Hero & Section Utilities === */
+.scn-hero {
+  text-align: center;
+  max-width: 820px;
+  margin: 0 auto 1.5rem;
+  padding: 1.2rem 0;
+}
+
+.scn-hero h2 {
+  margin: 0.4rem 0 0.45rem;
+}
+
+.scn-hero p {
+  margin: 0.3rem auto 0;
+  max-width: 720px;
+  color: var(--ink-500);
+}
+
+.scn-why-wrap {
+  margin-top: 0.85rem;
+}
+
+/* === Tables & Data === */
+.stDataFrame, .stTable {
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: var(--shadow-sm);
+}
+
+.stDataFrame tbody tr:nth-child(even) {
+  background: rgba(248, 250, 255, 0.6);
+}
+
+.stDataFrame tbody tr:hover {
+  background: rgba(79, 70, 229, 0.08);
 }
 
 /* === Miscellaneous === */
-.scn-why-wrap {
-  margin-top: 0.75rem;
+.stMarkdown div[data-testid="stMarkdownContainer"]:empty {
+  display: none !important;
 }
 
-/* === Responsive Design === */
+.stMarkdown ul {
+  padding-left: 1.4rem;
+}
+
+.stMarkdown ul li::marker {
+  color: var(--btn-primary);
+}
+
+[data-testid="stStatusWidget"] {
+  border-radius: 14px;
+  box-shadow: var(--shadow-sm);
+}
+
+[data-testid="stStatusWidget"] [data-testid="stMarkdownContainer"] {
+  color: var(--ink-700);
+}
+
+/* === Responsive Tweaks === */
 @media (max-width: 480px) {
   .block-container {
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-left: 1.1rem;
+    padding-right: 1.1rem;
   }
   .stRadio [role="radiogroup"] {
-    grid-template-columns: 1fr; /* Single column for mobile */
+    grid-template-columns: 1fr;
   }
   .scn-nav-row button {
-    min-width: 100px; /* Slightly smaller buttons on mobile */
+    min-width: 110px;
   }
   div[style*="grid-template-columns"] {
-    grid-template-columns: 1fr; /* Force single column on mobile */
+    grid-template-columns: 1fr;
   }
   div[style*="min-height: 250px"] {
-    min-height: 200px; /* Adjust for mobile height */
+    min-height: 220px;
   }
 }
 
-/* === Accessibility Enhancements for Cloud === */
+/* === Accessibility Enhancements === */
 .stRadio [role="radiogroup"] > label > div:last-child:focus {
   outline: 2px solid var(--btn-primary);
   outline-offset: 2px;
@@ -223,106 +591,17 @@ button[kind="secondary"]:hover {
   outline-offset: 2px;
 }
 
-/* === Streamlit Theme Overrides - Remove Orange === */
+/* === Streamlit Theme Overrides === */
 :root {
-  --primary-color: #2E6EFF;
-  --primary-color-light: #4D9EFF;
-  --primary-color-dark: #1F5AE6;
-  --background-color: #FFFFFF;
-  --secondary-background-color: #F9F9F9;
-  --text-color: #111827;
-    --font: "Segoe UI", sans-serif;
+  --primary-color: var(--btn-primary);
+  --primary-color-light: #6366f1;
+  --primary-color-dark: var(--btn-primary-hover);
+  --background-color: #eef2ff;
+  --secondary-background-color: #f8faff;
+  --text-color: var(--ink-900);
+  --font: var(--font-base);
 }
 
 .stApp {
   background-color: var(--background-color);
-}
-
-.stButton > button {
-  background-color: var(--btn-primary);
-  color: #FFFFFF;
-  border: none;
-  box-shadow: 0 2px 8px rgba(46, 110, 255, 0.25);
-}
-
-.stButton > button:hover {
-  background-color: var(--btn-primary-hover);
-}
-
-.stTextInput > div > input {
-  border-color: #E5E7EB;
-  background-color: #FFFFFF;
-}
-
-.stTextInput > div > input:focus {
-  border-color: var(--btn-primary);
-  box-shadow: 0 0 0 3px rgba(46, 110, 255, 0.1);
-}
-
-.stRadio > div > label > div {
-  background-color: var(--pill-bg);
-  color: var(--pill-text);
-  border: 1.5px solid var(--pill-brd);
-  box-shadow: var(--pill-shadow);
-}
-
-.stRadio > div > label > div:checked {
-  background-color: var(--pill-selected);
-  color: #FFFFFF;
-  border-color: var(--pill-selected);
-  box-shadow: 0 3px 12px rgba(17, 24, 39, 0.25);
-}
-
-.stCheckbox > label {
-  color: var(--text-color);
-}
-
-.stSelectbox > div > div {
-  background-color: #FFFFFF;
-  border-color: #E5E7EB;
-}
-
-.stSelectbox > div > div:focus {
-  border-color: var(--btn-primary);
-}
-
-.section-divider {
-  border-top: 1px solid #E5E7EB;
-}
-
-/* === AI Advisor Styling === */
-.stTextInput > div > input {
-  font-size: 16px;
-  padding: 0.5rem;
-}
-
-.stButton > button[kind="primary"] {
-  margin-top: 0.5rem;
-  padding: 0.5rem 1rem;
-}
-
-/* === Card and Tile Overrides === */
-div[style*="border: 1px solid #e0e0e0"] {
-  padding: 1.5rem;
-  margin: 0 auto;
-  max-width: 320px;
-  /* Comment: Card - keep padding and width consistent */
-}
-
-div[style*="min-height: 250px"] {
-  min-height: 250px;
-  /* Comment: Card height - lock for layout */
-}
-
-/* === Grid and Flex Overrides === */
-div[style*="grid-template-columns"] {
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 2rem;
-  /* Comment: Grid - enforce clean layout */
-}
-
-div[style*="display: flex"] {
-  justify-content: center;
-  gap: 2rem;
-  /* Comment: Flex - center and space evenly */
 }


### PR DESCRIPTION
## Summary
- switch the main app layout to the wide configuration so the new dev design has room to breathe
- refresh the global stylesheet with updated typography, gradients, sidebar styling, and component tokens tailored for the development experience
- add layout helpers, responsive tweaks, and refined controls (buttons, radios, inputs, tables) to create a cohesive visual system
- introduce a demphasized professional callout on the welcome page for discharge planners and referral partners

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68df6979c24083238dc157566787a3d4