### PR TITLE
Reframe audiencing journey and update care plan gating

### DIFF
--- a/audiencing.py
+++ b/audiencing.py
@@ -101,18 +101,13 @@ def compute_audiencing_route(
         urgent_feature_enabled = URGENT_FEATURE_FLAG
 
     reasons: list[str] = []
-    if qualifiers["on_medicaid"]:
-        next_route = "medicaid_off_ramp"
-        reasons.append("on_medicaid")
-    elif urgent_feature_enabled and qualifiers.get("urgent", False):
+    if urgent_feature_enabled and qualifiers.get("urgent", False):
         next_route = "pfma"
         reasons.append("urgent_case")
-    elif state.get("entry") == "pro":
-        next_route = "pro"
-        reasons.append("professional_entry")
     else:
-        next_route = "gcp"
-        reasons.append("default_gcp")
+        next_route = "contextual_welcome"
+        entry = state.get("entry") or "unknown"
+        reasons.append(f"entry_{entry}")
 
     route = state.setdefault("route", {})
     route["next"] = next_route

--- a/pages/contextual_welcome.py
+++ b/pages/contextual_welcome.py
@@ -1,0 +1,131 @@
+"""Bridge page that welcomes users based on their entry role."""
+from __future__ import annotations
+
+import streamlit as st
+
+from audiencing import ensure_audiencing_state, snapshot_audiencing
+from ui.components import card_panel
+from ui.theme import inject_theme
+
+
+ENTRY_COPY = {
+    "self": {
+        "headline": "Welcome, let's walk through a plan together",
+        "body": (
+            "We'll start with a few questions to understand your care needs and how you"
+            " feel about covering the costs. Then we'll craft a roadmap you can revisit"
+            " anytime."
+        ),
+        "accent": "We'll focus on what matters most for you—clarity, confidence, and next steps.",
+    },
+    "proxy": {
+        "headline": "We’re here to support you and your loved one",
+        "body": (
+            "First we'll learn a bit about their needs and your comfort with planning."
+            " From there, we'll recommend options and resources to help you feel ready."
+        ),
+        "accent": "We're alongside you with guidance that keeps family conversations warm and grounded.",
+    },
+    "pro": {
+        "headline": "Let’s prepare a plan you can share",
+        "body": (
+            "We’ll gather context quickly, then assemble guidance you can review with the"
+            " families you support. Everything stays clear, actionable, and advisor-friendly."
+        ),
+        "accent": "Keep it collaborative—tailor the plan and export highlights whenever you need.",
+    },
+}
+
+
+def safe_switch_page(target: str) -> None:
+    try:
+        st.switch_page(target)  # type: ignore[attr-defined]
+    except Exception:
+        st.query_params["next"] = target
+        st.experimental_rerun()
+
+
+def _ensure_care_context() -> dict[str, object]:
+    return st.session_state.setdefault(
+        "care_context",
+        {"person_name": "Your Loved One", "gcp_answers": {}, "gcp_recommendation": None},
+    )
+
+
+def _render_cards(accent: str) -> None:
+    columns = st.columns(3, gap="large")
+    card_specs = (
+        {
+            "title": "Personalized guidance",
+            "copy": "Answer a few context questions and we'll highlight the first moves to make.",
+        },
+        {
+            "title": "Care Planning Hub",
+            "copy": "Navigate between the Guided Care Plan, Cost Planner, and Advisor handoff easily.",
+        },
+        {
+            "title": "Ready for handoff",
+            "copy": accent,
+        },
+    )
+
+    for column, spec in zip(columns, card_specs):
+        with column:
+            with st.container(border=True):
+                st.markdown(f"**{spec['title']}**")
+                st.caption(spec["copy"])
+
+
+def render_contextual_welcome() -> None:
+    inject_theme()
+    st.set_page_config(page_title="Welcome to your Care Planning Hub", layout="centered")
+    st.markdown('<div class="sn-scope dashboard">', unsafe_allow_html=True)
+
+    debug_flag = bool(st.session_state.get("dev_debug"))
+
+    state = ensure_audiencing_state()
+    entry = state.get("entry") or "proxy"
+    copy = ENTRY_COPY.get(entry, ENTRY_COPY["proxy"])
+
+    _ensure_care_context()
+
+    with card_panel():
+        st.markdown(
+            f"""
+            <div class="sn-hero-h1" style="margin-bottom:.4rem;">{copy['headline']}</div>
+            <p style="margin:0;color:var(--ink-muted);font-size:1.05rem;">{copy['body']}</p>
+            """,
+            unsafe_allow_html=True,
+        )
+
+        st.markdown("<div class='sn-hr'></div>", unsafe_allow_html=True)
+
+        _render_cards(copy["accent"])
+
+        st.markdown("<div class='sn-hr'></div>", unsafe_allow_html=True)
+
+        cta_col, helper_col = st.columns([2, 1])
+        with cta_col:
+            if st.button(
+                "Continue to Care Planning Hub →",
+                type="primary",
+                use_container_width=True,
+            ):
+                safe_switch_page("pages/hub.py")
+        with helper_col:
+            st.caption(
+                "What is the Care Planning Hub? It's your home base for guided plans, cost tools, and advisor handoffs."
+            )
+
+    if debug_flag:
+        with st.expander("Debug: Contextual welcome", expanded=False):
+            st.json({
+                "audiencing": state,
+                "snapshot": st.session_state.get("audiencing_snapshot", snapshot_audiencing(state)),
+            })
+
+    st.markdown("</div>", unsafe_allow_html=True)
+
+
+render_contextual_welcome()
+

--- a/pages/gcp.py
+++ b/pages/gcp.py
@@ -1,87 +1,213 @@
+"""Guided Care Plan intro with financial context questions."""
 from __future__ import annotations
 
 import streamlit as st
-from ui.theme import inject_theme
 
-inject_theme()
-
-st.markdown('<div class="sn-scope gcp">', unsafe_allow_html=True)
-
-# pages/gcp.py
-"""Guided Care Plan intro with unified styling."""
-
-import streamlit as st
-
+from audiencing import (
+    apply_audiencing_sanitizer,
+    compute_audiencing_route,
+    ensure_audiencing_state,
+    snapshot_audiencing,
+)
 from guided_care_plan import ensure_gcp_session, render_stepper
 from guided_care_plan.state import current_audiencing_snapshot
-
+from ui.components import card_panel
 from ui.theme import inject_theme
 
-st.set_page_config(page_title="Guided Care Plan", layout="centered")
 
-# -------- helpers --------
+MEDICAID_OPTIONS = ("Yes", "No", "Unsure")
+FUNDING_OPTIONS = ("No worries", "Confident", "Unsure", "Not confident")
+MEDICAID_SESSION_KEY = "gcp_medicaid_choice"
+FUNDING_SESSION_KEY = "gcp_funding_confidence"
+
+
 def safe_switch_page(target: str) -> None:
-    """Try to navigate; if not available, fail softly."""
     try:
         st.switch_page(target)  # type: ignore[attr-defined]
     except Exception:
-        # As a fallback, set a query param and rerun to keep UX responsive.
         st.query_params["next"] = target
         st.experimental_rerun()
 
-# -------- state --------
-answers, gcp_result = ensure_gcp_session()
-snapshot = current_audiencing_snapshot()
 
-person_name = "Your Loved One"
-if snapshot.get("entry") == "self":
-    person_name = "You"
-else:
-    people = snapshot.get("people", {}) or {}
-    person_name = people.get("recipient_name") or "Your Loved One"
+def _ensure_gate_state() -> dict[str, object]:
+    return st.session_state.setdefault("gate", {})
 
-# -------- header --------
-st.title(f"Guided Care Plan for {person_name}")
-st.caption("Five quick sections to create a starting point and DecisionTrace.")
-render_stepper(0)
 
-# -------- intro copy (HTML allowed) --------
-st.markdown(
-    f"""
-Answer twelve short questions across daily life, safety, and context. We'll use them with your audience
-snapshot to surface a personalized care recommendation, highlight safety considerations, and point you back
-to the Concierge Care Hub with the right next steps.
-<div class="sn-card" style="margin-top:1.4rem;">
-  <p style="font-size:1rem; color:#475569; margin-bottom:0.6rem;">
-    You're planning for <strong>{person_name}</strong>. We'll reuse your audiencing details and apply the Guided Care Plan logic to highlight safety considerations, recommend a setting, and connect cost planning.
-  </p>
-  <ul style="color:#475569; line-height:1.7; margin-left:1.2rem;">
-    <li>Five sections with plain-language questions.</li>
-    <li>Automatically applies your household, benefits, and Medicaid context.</li>
-    <li>Produces a DecisionTrace for advisors and cost planning.</li>
-  </ul>
-</div>
-""",
-    unsafe_allow_html=True,
-)
-
-st.markdown("---")
-
-# -------- actions --------
-start_col, hub_col = st.columns([2, 1])
-with start_col:
-    if st.button("Start Section 1", type="primary"):
-        safe_switch_page("pages/gcp_daily_life.py")
-with hub_col:
-    if st.button("Return to Hub"):
-        safe_switch_page("pages/hub.py")
-
-# -------- debug --------
-with st.expander("Debug: Current answers", expanded=False):
-    st.json(
+def _ensure_care_context() -> dict[str, object]:
+    return st.session_state.setdefault(
+        "care_context",
         {
-            "answers": answers,
-            "gcp": gcp_result,
-            "audiencing": snapshot,
-        }
+            "person_name": "Your Loved One",
+            "gcp_answers": {},
+            "gcp_recommendation": None,
+            "gcp_cost": None,
+        },
     )
+
+
+def _persist_snapshot(state: dict[str, object]) -> None:
+    apply_audiencing_sanitizer(state)
+    compute_audiencing_route(state)
+    snapshot = snapshot_audiencing(state)
+    st.session_state["audiencing_snapshot"] = snapshot
+
+
+def _persist_medicaid(state: dict[str, object], choice: str | None) -> None:
+    qualifiers = state.setdefault("qualifiers", {})
+    if choice == "Yes":
+        qualifiers["on_medicaid"] = True
+    elif choice in {"No", "Unsure"}:
+        qualifiers["on_medicaid"] = False
+    apply_audiencing_sanitizer(state)
+    gate_state = _ensure_gate_state()
+    gate_state["medicaid_offramp_shown"] = False
+
+
+def _persist_gcp_context(choice: str | None, funding: str | None) -> None:
+    _, gcp_state = ensure_gcp_session()
+    if choice == "Yes":
+        gcp_state["payment_context"] = "medicaid"
+    elif choice in {"No", "Unsure"}:
+        gcp_state["payment_context"] = "private" if choice == "No" else "unknown"
+
+    if funding:
+        gcp_state["funding_confidence"] = funding.lower().replace(" ", "_")
+    elif funding is None:
+        gcp_state["funding_confidence"] = None
+
+
+def _render_funding_selector(current: str | None) -> str | None:
+    st.markdown("**How confident do you feel about paying for care?**")
+    cols = st.columns(len(FUNDING_OPTIONS), gap="small")
+    selected = current
+    for label, column in zip(FUNDING_OPTIONS, cols):
+        with column:
+            is_selected = selected == label
+            pressed = st.button(
+                label,
+                key=f"funding_chip_{label.lower().replace(' ', '_')}",
+                type="primary" if is_selected else "secondary",
+                use_container_width=True,
+            )
+            if pressed:
+                selected = None if is_selected else label
+    return selected
+
+
+def render_intro() -> None:
+    inject_theme()
+    st.set_page_config(page_title="Guided Care Plan", layout="centered")
+    st.markdown('<div class="sn-scope gcp">', unsafe_allow_html=True)
+
+    debug_flag = bool(st.session_state.get("dev_debug"))
+
+    state = ensure_audiencing_state()
+    answers, gcp_state = ensure_gcp_session()
+    current_snapshot = current_audiencing_snapshot()
+    care_context = _ensure_care_context()
+
+    people = state.get("people", {}) or {}
+    entry = state.get("entry")
+    if entry == "self":
+        person_name = people.get("recipient_name") or "you"
+        possessive = "your"
+    else:
+        person_name = people.get("recipient_name") or "your loved one"
+        possessive = "their"
+
+    if MEDICAID_SESSION_KEY not in st.session_state:
+        st.session_state[MEDICAID_SESSION_KEY] = None
+    if FUNDING_SESSION_KEY not in st.session_state:
+        st.session_state[FUNDING_SESSION_KEY] = None
+
+    st.title("Guided Care Plan")
+    st.caption("We’ll gather context in five sections and build a DecisionTrace at the end.")
+    render_stepper(0)
+
+    with card_panel():
+        st.markdown(
+            f"""
+            <div style="display:flex;flex-direction:column;gap:.4rem;">
+                <div style="font-size:1.2rem;font-weight:600;color:var(--ink);">Financial context</div>
+                <p style="margin:0;color:var(--ink-muted);">
+                    Care options depend a lot on insurance. If {possessive} coverage includes Medicaid, we'll guide you to resources built for Medicaid families.
+                </p>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+
+        medicaid_choice = st.radio(
+            "Is your loved one currently on Medicaid?",
+            options=MEDICAID_OPTIONS,
+            index=None,
+            key=MEDICAID_SESSION_KEY,
+            horizontal=True,
+            help="Medicaid is a state and federal program. If you’re on it, your options and next steps are different. We’ll point you to the right resources.",
+        )
+
+        _persist_medicaid(state, medicaid_choice)
+
+        info_placeholder = st.empty()
+        if medicaid_choice == "Yes":
+            info_placeholder.info(
+                "Because Medicaid changes the path, we’ll highlight resources and keep the full plan available."
+            )
+        elif medicaid_choice == "Unsure":
+            info_placeholder.info(
+                "Medicaid is different from Medicare. Medicaid is needs-based and can cover long-term support; Medicare focuses on medical care."
+            )
+
+        funding_choice = None
+        if medicaid_choice:
+            current_funding = st.session_state.get(FUNDING_SESSION_KEY)
+            funding_choice = _render_funding_selector(current_funding)
+            st.session_state[FUNDING_SESSION_KEY] = funding_choice
+        else:
+            st.session_state[FUNDING_SESSION_KEY] = None
+
+        _persist_gcp_context(medicaid_choice, funding_choice)
+
+        st.markdown("<div class='sn-hr'></div>", unsafe_allow_html=True)
+
+        st.markdown(
+            f"""
+            <p style="font-size:1rem;color:#475569;margin-bottom:0.6rem;">
+                You're planning for <strong>{person_name.title()}</strong>. We'll guide you through daily life, health & safety, and preferences to recommend the right care setting.
+            </p>
+            <ul style="color:#475569;line-height:1.7;margin-left:1.2rem;">
+                <li>Five sections with supportive, plain-language questions.</li>
+                <li>Adapts to your answers and keeps everything in one DecisionTrace.</li>
+                <li>Links directly to cost planning and advisor support when you're ready.</li>
+            </ul>
+            """,
+            unsafe_allow_html=True,
+        )
+
+        start_disabled = medicaid_choice is None
+        if st.button("Start Section 1", type="primary", use_container_width=True, disabled=start_disabled):
+            _persist_snapshot(state)
+            care_context["gcp_answers"] = answers
+            st.session_state["gcp"] = gcp_state
+            safe_switch_page("pages/gcp_daily_life.py")
+
+        if st.button("Return to Hub", use_container_width=True):
+            safe_switch_page("pages/hub.py")
+
+    if debug_flag:
+        with st.expander("Debug: GCP intro state", expanded=False):
+            st.json(
+                {
+                    "answers": answers,
+                    "gcp": gcp_state,
+                    "audiencing": st.session_state.get("audiencing_snapshot", current_snapshot),
+                    "medicaid_choice": medicaid_choice,
+                    "funding_choice": funding_choice,
+                }
+            )
+
+    st.markdown("</div>", unsafe_allow_html=True)
+
+
+render_intro()
+

--- a/pages/hub.py
+++ b/pages/hub.py
@@ -1,193 +1,170 @@
-"""Concierge Care Hub that adapts to the audiencing snapshot."""
+"""Care Planning Hub with three primary navigation tiles."""
 from __future__ import annotations
-
-
-from ui.theme import inject_theme
 
 import streamlit as st
 
-from audiencing import (
-
-    URGENT_FEATURE_FLAG,
-    apply_audiencing_sanitizer,
-    ensure_audiencing_state,
-    reset_audiencing_state,
-    snapshot_audiencing,
+from audiencing import apply_audiencing_sanitizer, ensure_audiencing_state, snapshot_audiencing
+from ui.components import card_panel
+from ui.theme import inject_theme
 
 
-)
-inject_theme()
-st.markdown('<div class="sn-scope dashboard">', unsafe_allow_html=True)
+def safe_switch_page(target: str) -> None:
+    try:
+        st.switch_page(target)  # type: ignore[attr-defined]
+    except Exception:
+        st.query_params["next"] = target
+        st.experimental_rerun()
 
 
-# Page config must be set before any UI output
-st.set_page_config(page_title="Concierge Care Hub", layout="wide")
+def _ensure_care_context() -> dict[str, object]:
+    return st.session_state.setdefault(
+        "care_context",
+        {
+            "person_name": "Your Loved One",
+            "gcp_answers": {},
+            "gcp_recommendation": None,
+            "gcp_cost": None,
+        },
+    )
 
-# ---------- Audiencing snapshot ----------
-state = ensure_audiencing_state()
-apply_audiencing_sanitizer(state)
-snapshot = snapshot_audiencing(state)
-st.session_state["audiencing_snapshot"] = snapshot
 
-# ---------- Session guard (fixed: closed parenthesis) ----------
-care_context = st.session_state.setdefault(
-    "care_context",
-    {
-        "person_name": "Your Loved One",
-        "gcp_answers": {},
-        "gcp_recommendation": None,  # 'In-home care' | 'Assisted living' | 'Memory care' | None
-        "gcp_cost": None,            # e.g., '$5,200/mo'
-    },
-)
-ctx = st.session_state.care_context
-person_name = ctx.get("person_name", "Your Loved One")
+def _determine_gcp_status() -> tuple[str, str, str]:
+    answers = st.session_state.get("gcp_answers", {})
+    gcp_state = st.session_state.get("gcp", {})
+    recommendation = gcp_state.get("recommended_setting")
 
-st.title("Dashboard")  # keep your H1; match your design copy if needed
+    if recommendation:
+        return "✔ Complete", "Open summary", "primary"
+    if answers:
+        return "In progress", "Resume plan", "primary"
+    return "Start here", "Begin plan", "primary"
 
-# ---------- Hub-only CSS fixes ----------
-# 1) Nuke any global "card decorators" that create empty rounded boxes above content.
-#    These often target Streamlit block wrappers or inject ::before/::after backgrounds.
-st.markdown(
-    """
-    <style>
-      /* Scope to this page only by wrapping all below in .hub-scope */
-      .hub-scope [data-testid="stVerticalBlock"],
-      .hub-scope [data-testid="stHorizontalBlock"] {
-        /* Remove any background/box/shadow/min-height global decorations */
-        background: transparent !important;
-        box-shadow: none !important;
-        border: none !important;
-        outline: none !important;
-        min-height: auto !important;
-      }
-      /* Kill pseudo-element decorations that some themes inject */
-      .hub-scope *::before,
-      .hub-scope *::after {
-        box-shadow: none !important;
-        background: none !important;
-      }
 
-      /* Our actual cards */
-      .sn-card {
-        background: #fff;
-        border: 1px solid rgba(2,6,23,0.08);
-        border-radius: 16px;
-        box-shadow: 0 2px 12px rgba(2,6,23,0.06);
-        padding: 22px;
-        margin: 24px 0;
-      }
-      .sn-title { font-weight: 800; font-size: 18px; margin: 0 0 6px 0; }
-      .sn-subtle { color: #475569; margin: 0 0 12px 0; }
-      .sn-status {
-        font-size: 12px;
-        padding: 6px 10px;
-        border-radius: 999px;
-        border: 1px solid rgba(2, 6, 23, 0.08);
-        background: #F8FAFC;
-        display: inline-block;
-      }
-      .sn-card .stButton>button {
-        padding: 10px 14px;
-        border-radius: 10px;
-        font-weight: 600;
-      }
-    </style>
-    """,
-    unsafe_allow_html=True,
-)
+def _determine_cost_status() -> tuple[str, str]:
+    cost_planner = st.session_state.get("cost_planner", {})
+    monthly_total = cost_planner.get("monthly_total")
+    if monthly_total:
+        return "In progress", "Review costs"
+    return "Optional", "Explore costs"
 
-# ---------- Page scope wrapper to confine the resets above ----------
-st.markdown('<div class="hub-scope">', unsafe_allow_html=True)
 
-def card(
+def _determine_pfma_status() -> tuple[str, str]:
+    pfma = st.session_state.get("pfma", {})
+    if pfma.get("appointment_booked"):
+        return "Scheduled", "View details"
+    return "Next step", "Connect now"
+
+
+def _render_tile(
+    *,
+    icon: str,
     title: str,
-    subtitle: str,
+    description: str,
+    status_label: str,
     cta_label: str,
-    cta_key: str,
-    on_click_page: str,
-    status: str | None = None,
+    cta_kind: str,
+    destination: str,
 ) -> None:
-    st.markdown('<div class="sn-card">', unsafe_allow_html=True)
-    # Use Streamlit columns for layout; they stay INSIDE our card because the card
-    # is a real DOM node, not a pseudo-element.
-    c1, c2, c3 = st.columns([6, 2, 2], vertical_alignment="center")
-    with c1:
-        st.markdown(f'<p class="sn-title">{title}</p>', unsafe_allow_html=True)
-        st.markdown(f'<p class="sn-subtle">{subtitle}</p>', unsafe_allow_html=True)
-    with c2:
-        if st.button(cta_label, key=cta_key):
-            st.switch_page(on_click_page)
-    with c3:
-        if status:
-            st.markdown(f'<span class="sn-status">{status}</span>', unsafe_allow_html=True)
-        else:
-            st.markdown("&nbsp;", unsafe_allow_html=True)
+    with st.container(border=True):
+        st.markdown(
+            f"""
+            <div style="display:flex;flex-direction:column;gap:.8rem;min-height:220px;">
+                <div style="font-size:2rem;">{icon}</div>
+                <div style="display:flex;justify-content:space-between;align-items:center;">
+                    <h3 style="margin:0;">{title}</h3>
+                    <span style="font-size:0.85rem;color:var(--ink-muted);">{status_label}</span>
+                </div>
+                <p style="margin:0;color:var(--ink-muted);">{description}</p>
+                <div style="margin-top:auto;">
+                    {""}
+                </div>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+        if st.button(cta_label, type=cta_kind, use_container_width=True, key=f"hub_{destination}"):
+            safe_switch_page(destination)
+
+
+def render_hub() -> None:
+    inject_theme()
+    st.set_page_config(page_title="Care Planning Hub", layout="wide")
+    st.markdown('<div class="sn-scope dashboard">', unsafe_allow_html=True)
+
+    debug_flag = bool(st.session_state.get("dev_debug"))
+
+    state = ensure_audiencing_state()
+    apply_audiencing_sanitizer(state)
+    snapshot = snapshot_audiencing(state)
+    st.session_state["audiencing_snapshot"] = snapshot
+
+    care_context = _ensure_care_context()
+    person_name = care_context.get("person_name", "Your Loved One")
+
+    with card_panel(padding="clamp(1.6rem, 3vw, 2.2rem)", gap="1.6rem"):
+        st.markdown(
+            f"""
+            <div style="display:flex;flex-direction:column;gap:.5rem;">
+                <div class="sn-hero-h1" style="font-size:2.2rem;">Care Planning Hub</div>
+                <p style="margin:0;color:var(--ink-muted);font-size:1.05rem;">
+                    This is your home base. Start with the Guided Care Plan, then explore cost planning and
+                    advisor support when you're ready. Everything adapts as you learn more about {person_name}.
+                </p>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+
+        gcp_status, gcp_cta, gcp_kind = _determine_gcp_status()
+        cost_status, cost_cta = _determine_cost_status()
+        pfma_status, pfma_cta = _determine_pfma_status()
+
+        cols = st.columns(3, gap="large")
+        with cols[0]:
+            _render_tile(
+                icon="🧭",
+                title="Guided Care Plan",
+                description="Answer step-by-step questions to understand needs, safety, and the best care setting.",
+                status_label=gcp_status,
+                cta_label=gcp_cta,
+                cta_kind=gcp_kind,
+                destination="pages/gcp.py",
+            )
+        with cols[1]:
+            _render_tile(
+                icon="💰",
+                title="Cost Planner",
+                description="Estimate monthly costs, compare scenarios, and see how benefits or savings play a role.",
+                status_label=cost_status,
+                cta_label=cost_cta,
+                cta_kind="secondary",
+                destination="pages/cost_planner.py",
+            )
+        with cols[2]:
+            _render_tile(
+                icon="🤝",
+                title="Plan for My Advisor",
+                description="Share your context with a concierge advisor who can help map the next moves.",
+                status_label=pfma_status,
+                cta_label=pfma_cta,
+                cta_kind="secondary",
+                destination="pages/pfma.py",
+            )
+
+    if debug_flag:
+        with st.expander("Debug: Hub state", expanded=False):
+            st.json(
+                {
+                    "audiencing": state,
+                    "snapshot": snapshot,
+                    "care_context": care_context,
+                    "gcp": st.session_state.get("gcp", {}),
+                    "cost_planner": st.session_state.get("cost_planner", {}),
+                }
+            )
+
     st.markdown("</div>", unsafe_allow_html=True)
 
-# ---------- Guided Care Plan ----------
-gcp_completed = bool(ctx.get("gcp_recommendation")) or bool(ctx.get("gcp_answers"))
-rec_text = ctx.get("gcp_recommendation") or "Understand the situation"
-cost_text = ctx.get("gcp_cost") or "In progress"
 
-card(
-    title="Guided Care Plan",
-    subtitle=(
-        f"{rec_text} * {cost_text}"
-        if gcp_completed
-        else f"See what we learned from your answers and refine the recommendation for {person_name}."
-    ),
-    cta_label=("Open" if gcp_completed else "Start guided plan"),
-    cta_key="hub_gcp_start",
-    on_click_page="pages/gcp.py",
-    status=("Completed ✅" if gcp_completed else "In progress"),
-)
+render_hub()
 
-# ---------- Cost Planner ----------
-card(
-    title="Cost Estimator",
-    subtitle=(
-        f"Assess the total cost scenarios across options for {person_name}. "
-        f"The estimate will update based on your guided plan."
-    ),
-    cta_label="Open estimator",
-    cta_key="hub_open_cp",
-    on_click_page="pages/cost_planner.py",
-)
-
-# ---------- Plan for My Advisor ----------
-card(
-    title="Plan for My Advisor",
-    subtitle="Book time with a concierge advisor and share your plan.",
-    cta_label="Get connected",
-    cta_key="hub_pfma",
-    on_click_page="pages/pfma.py",
-)
-
-# ---------- Medication Management ----------
-card(
-    title="Medication Management",
-    subtitle="Keep meds on track with simple reminders and checks.",
-    cta_label="Open",
-    cta_key="hub_meds",
-    on_click_page="pages/medication_management.py",
-)
-
-# ---------- Risk Navigator ----------
-card(
-    title="Risk Navigator",
-    subtitle="Quick safety check to reduce avoidable risks at home.",
-    cta_label="Run check",
-    cta_key="hub_risk",
-    on_click_page="pages/risk_navigator.py",
-)
-
-# ---------- Assessment (last) ----------
-card(
-    title="Assessment",
-    subtitle="Additional screening tools and forms.",
-    cta_label="Open assessment",
-    cta_key="hub_assess",
-    on_click_page="pages/care_plan_confirm.py",
-)
-
-st.markdown("</div>", unsafe_allow_html=True)  # end .hub-scope

--- a/pages/medicaid.py
+++ b/pages/medicaid.py
@@ -1,0 +1,51 @@
+"""Medicaid off-ramp page with curated resource links."""
+from __future__ import annotations
+
+import streamlit as st
+
+from ui.components import card_panel
+from ui.theme import inject_theme
+
+
+inject_theme()
+st.set_page_config(page_title="Medicaid Resources", layout="centered")
+st.markdown('<div class="sn-scope dashboard">', unsafe_allow_html=True)
+
+with card_panel():
+    st.markdown(
+        """
+        <div class="sn-hero-h1" style="margin-bottom:.4rem;">Medicaid Resources for Your Loved One</div>
+        <p style="margin:0;color:var(--ink-muted);font-size:1.05rem;">
+          Because your loved one is on Medicaid, there are special programs and benefits you may qualify for.
+          Medicaid has federally and state-supported options that can help with senior living, long-term care, and related services.
+          While our direct resources are limited in this area, we’ve included information and links to trusted organizations that can guide you to the right support.
+        </p>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    resources = [
+        ("State Medicaid Office", "Visit State Directory →"),
+        ("Area Agencies on Aging", "Find an Agency →"),
+        ("National Council on Aging", "Explore Resources →"),
+        ("Community Health Centers", "Search Centers →"),
+    ]
+
+    cols = st.columns(2, gap="large")
+    for idx, (title, cta) in enumerate(resources):
+        with cols[idx % 2]:
+            st.markdown(
+                f"""
+                <div class="sn-field-card" style="display:flex;flex-direction:column;gap:.5rem;min-height:150px;">
+                    <div style="font-weight:700;color:var(--ink);font-size:1.05rem;">{title}</div>
+                    <a href="#" target="_blank" style="font-weight:600;">{cta}</a>
+                </div>
+                """,
+                unsafe_allow_html=True,
+            )
+
+    st.markdown("<div class='sn-hr'></div>", unsafe_allow_html=True)
+
+    st.link_button("Explore Resources", "#", use_container_width=True)
+
+st.markdown("</div>", unsafe_allow_html=True)

--- a/ui/components.py
+++ b/ui/components.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 from typing import Callable, Iterable, Optional
 
 import streamlit as st
@@ -100,3 +101,19 @@ def pills(
     if help_text:
         st.caption(help_text)
     return selected
+
+
+@contextmanager
+def card_panel(*, padding: str | None = None, gap: str = "1.4rem"):
+    """Context manager that renders content inside a themed card panel."""
+
+    padding_css = padding or "clamp(1.8rem, 3vw, 2.4rem)"
+    style = f"padding:{padding_css};display:flex;flex-direction:column;gap:{gap};"
+    st.markdown(
+        f'<div class="sn-card" style="{style}">',
+        unsafe_allow_html=True,
+    )
+    try:
+        yield
+    finally:
+        st.markdown("</div>", unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- reshape the Tell Us About entry screens into role-selection tiles that persist state and route into a contextual welcome bridge
- introduce a contextual welcome page and redesign the Care Planning Hub around the Guided Care Plan, Cost Planner, and advisor handoff
- move Medicaid and funding confidence questions into the GCP intro and update the recommendation page with the integrated Medicaid off-ramp logic

## Testing
- python -m compileall pages guided_care_plan ui

------
https://chatgpt.com/codex/tasks/task_b_68e053dd28308323ac575337cd379a04