### PR TITLE
Apply cost planner wireframe template across flows

### DIFF
--- a/cost_planner_wireframes.py
+++ b/cost_planner_wireframes.py
@@ -1,0 +1,1156 @@
+from __future__ import annotations
+
+"""Streamlit mock-ups for every Cost Planner page.
+
+The product team requested a consistent set of wireframes that demonstrate how the
+TurboTax-inspired visual language applies to each `cost_plan*` and
+`cost_planner*` page. This module focuses on layout, tone, and interaction affordances
+without introducing business logic or page routing side-effects.
+"""
+
+from dataclasses import dataclass
+from typing import Callable, Dict, List
+
+import streamlit as st
+
+from cost_planner_shared import format_currency
+from ui.theme import inject_theme
+
+
+inject_theme()
+
+
+def apply_global_styles() -> None:
+    """Inject shared CSS for the Cost Planner mock-ups."""
+
+    st.markdown(
+        """
+<style>
+/* Header and Navigation */
+.stAppHeader { background-color: #f0f8ff; padding: 1rem; border-bottom: 1px solid #d3d3d3; }
+.stAppHeader h1 { color: #1e90ff; font-size: 24px; margin: 0; }
+.nav-bar { display: flex; justify-content: space-between; align-items: center; gap: 1rem; }
+.nav-item { color: #4682b4; margin-right: 1rem; text-decoration: none; font-weight: 500; }
+.login-btn { background-color: #1e90ff; color: white; padding: 0.5rem 1rem; border-radius: 20px; border: none; font-weight: 600; }
+
+/* Qualifiers Header */
+.qual-header { display: flex; align-items: center; padding: 1rem; border-bottom: 1px solid #d3d3d3; gap: 0.75rem; }
+.back-btn { color: #1e90ff; font-size: 18px; cursor: pointer; }
+.assess-label { color: #808080; font-size: 14px; }
+.name-btn { background-color: #f0f8ff; color: #1e90ff; border-radius: 20px; padding: 0.2rem 0.8rem; border: 0; font-weight: 600; }
+.question-mode { color: #1e90ff; font-size: 14px; margin-left: auto; }
+
+/* Wizard Styling */
+.wizard-hero { background: #f0f8ff; padding: 2rem; text-align: center; border-radius: 20px; margin-bottom: 2rem; }
+.wizard-title { font-size: 32px; color: #1e90ff; margin-bottom: 0.5rem; }
+.wizard-caption { font-size: 17px; color: #808080; max-width: 720px; margin: 0 auto; }
+.wizard-help { background-color: #f0f8ff; color: #606060; padding: 0.75rem 1rem; border-radius: 12px; margin-top: 1.25rem; border: 1px solid #d3d3d3; }
+.wizard-button { padding: 0.5rem 1.25rem; border-radius: 20px; font-weight: 600; display: inline-flex; align-items: center; justify-content: center; border: none; cursor: pointer; }
+.wizard-button-primary { background-color: #1e90ff; color: white; }
+.wizard-button-secondary { background-color: #f0f8ff; color: #1e90ff; border: 1px solid #d3d3d3; }
+.wizard-suggestion { padding: 1rem; border-radius: 12px; margin-bottom: 1rem; font-size: 15px; }
+.wizard-suggestion-info { background-color: #e6f0fa; color: #1e90ff; }
+.wizard-suggestion-warn { background-color: #fff3cd; color: #856404; }
+.wizard-suggestion-critical { background-color: #f8d7da; color: #721c24; }
+
+/* Module dashboard cards */
+.module-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; margin: 1.5rem 0; }
+.module-card { background: #ffffff; border-radius: 18px; padding: 1.25rem; border: 1px solid #d3d3d3; box-shadow: 0 12px 30px rgba(30, 144, 255, 0.08); display: flex; flex-direction: column; gap: 0.5rem; }
+.module-card h4 { margin: 0; font-size: 18px; color: #1e90ff; }
+.module-card p { margin: 0; color: #606060; font-size: 14px; }
+.module-card .card-status { display: inline-flex; align-items: center; gap: 0.35rem; background: #f0f8ff; color: #1e90ff; padding: 0.15rem 0.75rem; border-radius: 999px; font-size: 13px; font-weight: 600; }
+.module-card .card-status.positive { background: #e6f7eb; color: #2e8b57; }
+.module-card .card-status.warning { background: #fff3cd; color: #856404; }
+.module-card .card-actions { margin-top: auto; display: flex; gap: 0.5rem; }
+.module-card .card-actions a { text-decoration: none; }
+.module-card .card-actions .wizard-button { width: 100%; }
+
+/* Tables */
+.summary-table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+.summary-table th { text-align: left; font-size: 14px; color: #606060; border-bottom: 1px solid #d3d3d3; padding-bottom: 0.5rem; }
+.summary-table td { padding: 0.65rem 0; border-bottom: 1px solid #ededed; font-size: 15px; }
+.summary-table td.amount { text-align: right; font-weight: 600; color: #1e90ff; }
+
+/* Utility */
+.sn-scope.dashboard.cost-planner-wireframe { padding-bottom: 2rem; }
+</style>
+""",
+        unsafe_allow_html=True,
+    )
+
+
+def start_container() -> None:
+    st.markdown('<div class="sn-scope dashboard cost-planner-wireframe">', unsafe_allow_html=True)
+
+
+def end_container() -> None:
+    st.markdown("</div>", unsafe_allow_html=True)
+
+
+def render_app_header() -> None:
+    st.markdown(
+        """
+<div class="stAppHeader">
+  <div class="nav-bar">
+    <h1>Concierge Care Senior Navigator</h1>
+    <div>
+      <a class="nav-item" href="#">Dashboard</a>
+      <a class="nav-item" href="#">Learning Center</a>
+      <a class="nav-item" href="#">Get Connected</a>
+      <button class="login-btn">Log in or sign up</button>
+    </div>
+  </div>
+</div>
+""",
+        unsafe_allow_html=True,
+    )
+
+
+def render_assessment_header(section_label: str, *, persona: str = "John", mode: str = "All questions") -> None:
+    st.markdown(
+        f"""
+<div class="qual-header">
+  <span class="back-btn">← Back</span>
+  <span class="assess-label">{section_label}</span>
+  <button class="name-btn">{persona}</button>
+  <span class="question-mode">{mode}</span>
+</div>
+""",
+        unsafe_allow_html=True,
+    )
+
+
+def render_wizard_hero(title: str, caption: str) -> None:
+    st.markdown("<div class='wizard-hero'>", unsafe_allow_html=True)
+    st.markdown(f"<h1 class='wizard-title'>{title}</h1>", unsafe_allow_html=True)
+    st.markdown(f"<p class='wizard-caption'>{caption}</p>", unsafe_allow_html=True)
+    st.markdown("</div>", unsafe_allow_html=True)
+
+
+def render_wizard_help(text: str) -> None:
+    st.markdown(f"<div class='wizard-help'>{text}</div>", unsafe_allow_html=True)
+
+
+def render_metrics(metrics: List[Dict[str, str]]) -> None:
+    if not metrics:
+        return
+
+    cols = st.columns(len(metrics))
+    for col, metric in zip(cols, metrics):
+        with col:
+            st.metric(metric.get("label", ""), metric.get("value", ""), metric.get("delta"))
+
+
+def render_nav_buttons(buttons: List[Dict[str, str]]) -> None:
+    if not buttons:
+        return
+
+    cols = st.columns(len(buttons))
+    for col, button in zip(cols, buttons):
+        with col:
+            st.button(
+                button.get("label", ""),
+                type=button.get("type", "secondary"),
+                key=f"nav_{button.get('key', button.get('label', 'btn')).replace(' ', '_').lower()}",
+            )
+
+
+def render_module_cards(cards: List[Dict[str, str]]) -> None:
+    if not cards:
+        return
+
+    card_html = "<div class='module-grid'>"
+    for card in cards:
+        status_class = card.get("status_class", "")
+        card_html += (
+            f"<div class='module-card'>"
+            f"  <span class='card-status {status_class}'>{card.get('status', '')}</span>"
+            f"  <h4>{card.get('title', '')}</h4>"
+            f"  <p>{card.get('body', '')}</p>"
+            f"  <div class='card-actions'>"
+            f"    <a class='wizard-button wizard-button-primary' href='#'>{card.get('primary_label', 'Open')}</a>"
+            f"  </div>"
+            f"</div>"
+        )
+    card_html += "</div>"
+    st.markdown(card_html, unsafe_allow_html=True)
+
+
+def render_fields(page_key: str, fields: List[Dict[str, object]]) -> None:
+    for field in fields:
+        columns = field.get("columns")
+        if columns:
+            cols = st.columns(columns)
+            for container, item in zip(cols, field.get("items", [])):
+                with container:
+                    render_field(page_key, item)
+        else:
+            render_field(page_key, field)
+
+
+def render_field(page_key: str, field: Dict[str, object]) -> None:
+    field_type = field.get("type", "number")
+    label = field.get("label", "")
+    key = f"{page_key}_{field.get('key', label).replace(' ', '_').lower()}"
+    help_text = field.get("help")
+    label_visibility = field.get("label_visibility")
+
+    if field_type == "number":
+        st.number_input(
+            label,
+            min_value=field.get("min", 0.0),
+            step=field.get("step", 1.0),
+            value=field.get("value", 0.0),
+            key=key,
+            help=help_text,
+        )
+    elif field_type == "select":
+        st.selectbox(
+            label,
+            field.get("options", []),
+            index=field.get("index", 0),
+            key=key,
+            help=help_text,
+        )
+    elif field_type == "checkbox":
+        st.checkbox(label, value=field.get("value", False), key=key, help=help_text)
+    elif field_type == "text":
+        st.text_input(label, value=field.get("value", ""), key=key, help=help_text)
+    elif field_type == "textarea":
+        st.text_area(
+            label,
+            value=field.get("value", ""),
+            key=key,
+            help=help_text,
+            height=field.get("height", 120),
+        )
+    elif field_type == "radio":
+        st.radio(
+            label,
+            field.get("options", []),
+            index=field.get("index", 0),
+            horizontal=field.get("horizontal", False),
+            key=key,
+            help=help_text,
+            label_visibility=label_visibility,
+        )
+    elif field_type == "slider":
+        st.slider(
+            label,
+            min_value=field.get("min", 0),
+            max_value=field.get("max", 100),
+            value=field.get("value", 0),
+            step=field.get("step", 1),
+            key=key,
+            help=help_text,
+        )
+
+
+def render_module_page(
+    page_key: str,
+    *,
+    section_label: str = "Guided Cost Plan",
+    persona: str = "John",
+    mode: str = "Single question",
+    title: str,
+    caption: str,
+    fields: List[Dict[str, object]],
+    metrics: List[Dict[str, str]],
+    nav_buttons: List[Dict[str, str]],
+    helper_text: str,
+    callouts: List[Dict[str, str]] | None = None,
+) -> None:
+    start_container()
+    render_assessment_header(section_label, persona=persona, mode=mode)
+    st.subheader(title)
+    st.caption(caption)
+
+    for callout in callouts or []:
+        st.markdown(
+            f"<div class='wizard-suggestion wizard-suggestion-{callout.get('tone', 'info')}'>"
+            f"{callout.get('text', '')}</div>",
+            unsafe_allow_html=True,
+        )
+
+    render_fields(page_key, fields)
+    render_metrics(metrics)
+    render_wizard_help(helper_text)
+    render_nav_buttons(nav_buttons)
+    end_container()
+
+
+def render_cost_planner_mode_selector() -> None:
+    start_container()
+    render_app_header()
+    render_wizard_hero("Cost Planner", "Choose how you'd like to plan care costs.")
+
+    col1, col2 = st.columns(2)
+    with col1:
+        st.button(
+            "Explore Costs",
+            key="wireframe_explore_mode",
+            type="primary",
+            use_container_width=True,
+        )
+        st.caption("Quick estimate, no login needed.")
+    with col2:
+        st.button(
+            "Plan Costs",
+            key="wireframe_plan_mode",
+            type="primary",
+            use_container_width=True,
+        )
+        st.caption("Detailed plan, requires login.")
+
+    st.markdown("---")
+    st.caption("© 2025 Concierge Care Senior Navigator™")
+    end_container()
+
+
+def render_cost_planner_qualifiers() -> None:
+    start_container()
+    render_assessment_header("Assessment: For someone")
+    st.subheader("Guided Cost Plan")
+    st.markdown(
+        "<h3>How would you describe your financial situation when it comes to paying for care? <span style='color: #1e90ff;'>ⓘ</span></h3>",
+        unsafe_allow_html=True,
+    )
+    st.radio(
+        "",
+        [
+            "I don't worry about money",
+            "I'm financially comfortable",
+            "Cost is a major factor",
+            "I may need financial help",
+        ],
+        horizontal=True,
+        label_visibility="collapsed",
+        key="qual_financial_situation",
+    )
+
+    st.markdown(
+        "<h3>Contribution style <span style='color: #1e90ff;'>ⓘ</span></h3>",
+        unsafe_allow_html=True,
+    )
+    contribution = st.radio(
+        "",
+        ["Unified contribution", "Individual contributions"],
+        horizontal=True,
+        label_visibility="collapsed",
+        key="qual_contribution",
+    )
+    if contribution == "Individual contributions":
+        st.text_input("Add contributor (e.g., Sibling 1)", key="qual_contributor_entry")
+
+    st.markdown(
+        "<h3>Do you own your home? <span style='color: #1e90ff;'>ⓘ</span></h3>",
+        unsafe_allow_html=True,
+    )
+    st.radio(
+        "",
+        ["Yes", "No"],
+        horizontal=True,
+        label_visibility="collapsed",
+        key="qual_owns_home",
+    )
+
+    st.markdown(
+        "<h3>Are you a veteran? <span style='color: #1e90ff;'>ⓘ</span></h3>",
+        unsafe_allow_html=True,
+    )
+    st.radio(
+        "",
+        ["Yes", "No"],
+        horizontal=True,
+        label_visibility="collapsed",
+        key="qual_is_veteran",
+    )
+
+    render_nav_buttons(
+        [
+            {"label": "Continue", "type": "primary", "key": "qual_continue"},
+            {"label": "Skip", "type": "secondary", "key": "qual_skip"},
+        ]
+    )
+    render_wizard_help("Respond as the person receiving care even if you're filling this out for someone else.")
+    end_container()
+
+
+def render_cost_planner_estimate() -> None:
+    start_container()
+    render_assessment_header("Guided Cost Plan", mode="All questions")
+    st.subheader("Tell us about your situation")
+    st.caption("A few quick selections keep your estimate on track.")
+
+    render_fields(
+        "estimate",
+        [
+            {
+                "type": "radio",
+                "label": "Planning mode",
+                "options": ["Estimate costs", "Plan in detail"],
+                "horizontal": True,
+                "key": "planning_mode",
+            },
+            {
+                "type": "radio",
+                "label": "Household structure",
+                "options": ["Just me", "Me + partner", "Multi-person"],
+                "horizontal": True,
+                "key": "household",
+            },
+            {
+                "columns": 2,
+                "items": [
+                    {
+                        "type": "slider",
+                        "label": "How soon do you need care?",
+                        "min": 0,
+                        "max": 12,
+                        "value": 3,
+                        "step": 1,
+                        "help": "0 = now, 12 = a year out",
+                        "key": "timeline",
+                    },
+                    {
+                        "type": "number",
+                        "label": "Monthly budget target",
+                        "value": 4000.0,
+                        "step": 100.0,
+                        "help": "Helps us frame recommendations and offsets.",
+                        "key": "budget",
+                    },
+                ],
+            },
+            {
+                "type": "checkbox",
+                "label": "I'd like to explore financial assistance options",
+                "value": True,
+                "key": "assistance_interest",
+            },
+        ],
+    )
+
+    render_metrics(
+        [
+            {"label": "Monthly snapshot", "value": format_currency(4850)},
+            {"label": "Potential offsets", "value": format_currency(1650)},
+            {"label": "Net out-of-pocket", "value": format_currency(3200)},
+        ]
+    )
+
+    render_wizard_help("These inputs preview your estimate. You can revisit any time from the module list.")
+    render_nav_buttons(
+        [
+            {"label": "Back", "type": "secondary", "key": "estimate_back"},
+            {"label": "Continue to modules", "type": "primary", "key": "estimate_continue"},
+        ]
+    )
+    end_container()
+
+
+def render_cost_planner_modules() -> None:
+    start_container()
+    render_assessment_header("Guided Cost Plan", mode="Module view")
+    st.subheader("Pick where to focus next")
+    st.caption("Work through modules in any order. Navi highlights what's most urgent.")
+
+    render_module_cards(
+        [
+            {
+                "title": "Housing",
+                "body": "Base rent, utilities, maintenance, and community fees.",
+                "status": "In progress • 2 of 3 complete",
+                "status_class": "warning",
+                "primary_label": "Open housing",
+            },
+            {
+                "title": "In-home care",
+                "body": "Staffing plans, supplemental services, and second-person support.",
+                "status": "Not started",
+                "status_class": "",
+                "primary_label": "Start module",
+            },
+            {
+                "title": "Medical & daily aids",
+                "body": "Prescriptions, supplies, transportation, and monitoring.",
+                "status": "Ready for review",
+                "status_class": "positive",
+                "primary_label": "Review items",
+            },
+            {
+                "title": "Benefits & income",
+                "body": "Insurance premiums, Social Security, pensions, and VA benefits.",
+                "status": "Needs info",
+                "status_class": "warning",
+                "primary_label": "Add offsets",
+            },
+            {
+                "title": "Upgrades & safety",
+                "body": "Home modifications and fall-prevention investments.",
+                "status": "Optional",
+                "status_class": "",
+                "primary_label": "Explore options",
+            },
+            {
+                "title": "Notes & extras",
+                "body": "Custom line items, debts, and planner notes for your family.",
+                "status": "Draft saved",
+                "status_class": "positive",
+                "primary_label": "Edit notes",
+            },
+        ]
+    )
+
+    render_metrics(
+        [
+            {"label": "Modules complete", "value": "4 / 7"},
+            {"label": "Monthly snapshot", "value": format_currency(6120)},
+            {"label": "Net out-of-pocket", "value": format_currency(3475)},
+        ]
+    )
+
+    render_wizard_help("Navi suggests completing Housing next so your monthly baseline is accurate before offsets.")
+    render_nav_buttons(
+        [
+            {"label": "Return to estimate", "type": "secondary", "key": "modules_back"},
+            {"label": "View skipped items", "type": "secondary", "key": "modules_skipped"},
+            {"label": "Go to summary", "type": "primary", "key": "modules_summary"},
+        ]
+    )
+    end_container()
+
+
+def render_cost_planner_housing() -> None:
+    render_module_page(
+        "housing",
+        title="Housing & living costs",
+        caption="Capture recurring housing payments before care or benefits.",
+        fields=[
+            {
+                "type": "number",
+                "label": "Monthly housing cost (rent, mortgage, or community fee)",
+                "value": 2850.0,
+                "step": 50.0,
+                "help": "Include base rent, mortgage, or community fees.",
+                "key": "base",
+            },
+            {
+                "columns": 2,
+                "items": [
+                    {
+                        "type": "number",
+                        "label": "Utilities & services",
+                        "value": 210.0,
+                        "step": 25.0,
+                        "key": "utilities",
+                    },
+                    {
+                        "type": "number",
+                        "label": "Maintenance or HOA",
+                        "value": 140.0,
+                        "step": 25.0,
+                        "key": "maintenance",
+                    },
+                ],
+            },
+        ],
+        metrics=[
+            {"label": "Housing subtotal", "value": format_currency(3200)},
+        ],
+        nav_buttons=[
+            {"label": "Skip", "type": "secondary", "key": "housing_skip"},
+            {"label": "Save & continue", "type": "primary", "key": "housing_continue"},
+        ],
+        helper_text="Include rent, mortgage, or assisted living base fees. We hide maintenance if the household rents.",
+        callouts=[
+            {
+                "tone": "info",
+                "text": "Navi tip: Owners can explore reverse mortgage counseling in the benefits module.",
+            }
+        ],
+    )
+
+
+def render_cost_planner_home_care() -> None:
+    render_module_page(
+        "home_care",
+        title="In-home care",
+        caption="Capture staffing, add-ons, and second-person coverage.",
+        fields=[
+            {
+                "columns": 2,
+                "items": [
+                    {
+                        "type": "number",
+                        "label": "Weekly caregiver hours",
+                        "value": 38.0,
+                        "step": 1.0,
+                        "help": "Total paid hours per week across all caregivers.",
+                        "key": "hours",
+                    },
+                    {
+                        "type": "number",
+                        "label": "Base hourly rate",
+                        "value": 28.0,
+                        "step": 1.0,
+                        "help": "Hourly cost from your agency or private caregiver.",
+                        "key": "rate",
+                    },
+                ],
+            },
+            {
+                "columns": 2,
+                "items": [
+                    {
+                        "type": "number",
+                        "label": "Weekend / night add-ons",
+                        "value": 260.0,
+                        "step": 25.0,
+                        "key": "addons",
+                    },
+                    {
+                        "type": "number",
+                        "label": "Second-person support",
+                        "value": 340.0,
+                        "step": 25.0,
+                        "key": "second_person",
+                    },
+                ],
+            },
+            {
+                "type": "checkbox",
+                "label": "Include respite coverage",
+                "value": True,
+                "key": "respite",
+            },
+        ],
+        metrics=[
+            {"label": "Care subtotal", "value": format_currency(4520)},
+            {"label": "Hours/week", "value": "38"},
+        ],
+        nav_buttons=[
+            {"label": "Skip", "type": "secondary", "key": "home_care_skip"},
+            {"label": "Save & continue", "type": "primary", "key": "home_care_continue"},
+        ],
+        helper_text="Include agency fees, respite coverage, and any second-person surcharges when applicable.",
+        callouts=[
+            {
+                "tone": "warn",
+                "text": "Navi: You're planning more than 40 hours/week. Consider rotating caregivers to avoid overtime rates.",
+            }
+        ],
+    )
+
+
+def render_cost_planner_daily_aids() -> None:
+    render_module_page(
+        "daily_aids",
+        title="Medical & daily living aids",
+        caption="Log recurring medical supplies, prescriptions, and transportation needs.",
+        fields=[
+            {
+                "columns": 2,
+                "items": [
+                    {
+                        "type": "number",
+                        "label": "Prescription medications",
+                        "value": 185.0,
+                        "step": 10.0,
+                        "key": "rx",
+                    },
+                    {
+                        "type": "number",
+                        "label": "Medical supplies",
+                        "value": 95.0,
+                        "step": 5.0,
+                        "key": "supplies",
+                    },
+                ],
+            },
+            {
+                "columns": 2,
+                "items": [
+                    {
+                        "type": "number",
+                        "label": "Transportation & delivery",
+                        "value": 120.0,
+                        "step": 10.0,
+                        "key": "transport",
+                    },
+                    {
+                        "type": "checkbox",
+                        "label": "Chronic condition support needed",
+                        "value": True,
+                        "key": "chronic",
+                    },
+                ],
+            },
+        ],
+        metrics=[
+            {"label": "Medical subtotal", "value": format_currency(400)},
+        ],
+        nav_buttons=[
+            {"label": "Skip", "type": "secondary", "key": "daily_aids_skip"},
+            {"label": "Save & continue", "type": "primary", "key": "daily_aids_continue"},
+        ],
+        helper_text="Capture prescriptions, medical supplies, and mobility or delivery costs for a full medical picture.",
+        callouts=[
+            {
+                "tone": "info",
+                "text": "Navi: Medicare Part D might offset prescriptions over $150/month. Add potential savings in benefits.",
+            }
+        ],
+    )
+
+
+def render_cost_planner_benefits() -> None:
+    render_module_page(
+        "benefits",
+        section_label="Offsets & benefits",
+        mode="All sources",
+        title="Benefits & income",
+        caption="Log insurance premiums, regular income, and financial assistance.",
+        fields=[
+            {
+                "columns": 2,
+                "items": [
+                    {
+                        "type": "number",
+                        "label": "Monthly health premiums",
+                        "value": 410.0,
+                        "step": 25.0,
+                        "key": "health_premium",
+                    },
+                    {
+                        "type": "number",
+                        "label": "Long-term care insurance",
+                        "value": 0.0,
+                        "step": 25.0,
+                        "key": "ltc_premium",
+                    },
+                ],
+            },
+            {
+                "columns": 2,
+                "items": [
+                    {
+                        "type": "number",
+                        "label": "Social Security income",
+                        "value": 2150.0,
+                        "step": 50.0,
+                        "key": "ss_income",
+                    },
+                    {
+                        "type": "number",
+                        "label": "Pension or annuity",
+                        "value": 650.0,
+                        "step": 50.0,
+                        "key": "pension_income",
+                    },
+                ],
+            },
+            {
+                "columns": 2,
+                "items": [
+                    {
+                        "type": "number",
+                        "label": "VA or other benefits",
+                        "value": 450.0,
+                        "step": 25.0,
+                        "key": "va_benefits",
+                    },
+                    {
+                        "type": "checkbox",
+                        "label": "Medicaid application in progress",
+                        "value": False,
+                        "key": "medicaid_progress",
+                    },
+                ],
+            },
+        ],
+        metrics=[
+            {"label": "Offsets subtotal", "value": format_currency(3250)},
+            {"label": "Insurance spend", "value": format_currency(410)},
+        ],
+        nav_buttons=[
+            {"label": "Skip", "type": "secondary", "key": "benefits_skip"},
+            {"label": "Save & continue", "type": "primary", "key": "benefits_continue"},
+        ],
+        helper_text="Track every offset and premium so Navi can surface your true out-of-pocket costs.",
+        callouts=[
+            {
+                "tone": "info",
+                "text": "Navi: Upload pension statements in Documents to keep this figure current.",
+            }
+        ],
+    )
+
+
+def render_cost_planner_freeform() -> None:
+    render_module_page(
+        "freeform",
+        title="Notes & extras",
+        caption="Add custom line items, debts, or notes for your family.",
+        fields=[
+            {
+                "type": "text",
+                "label": "Custom expense name",
+                "value": "Meal delivery",
+                "key": "custom_name",
+            },
+            {
+                "type": "number",
+                "label": "Monthly amount",
+                "value": 180.0,
+                "step": 10.0,
+                "key": "custom_amount",
+            },
+            {
+                "type": "textarea",
+                "label": "Notes for loved ones",
+                "value": "Remember to ask the care manager about sliding-scale transportation passes.",
+                "key": "notes",
+            },
+        ],
+        metrics=[
+            {"label": "Other subtotal", "value": format_currency(180)},
+        ],
+        nav_buttons=[
+            {"label": "Skip", "type": "secondary", "key": "freeform_skip"},
+            {"label": "Save & continue", "type": "primary", "key": "freeform_continue"},
+        ],
+        helper_text="Use this space for one-off costs or context your family should remember during decision-making.",
+        callouts=[
+            {
+                "tone": "info",
+                "text": "Navi: Add debt repayments if they impact monthly cash flow.",
+            }
+        ],
+    )
+
+
+def render_cost_planner_mods() -> None:
+    render_module_page(
+        "mods",
+        section_label="Upgrades & safety",
+        mode="Project review",
+        title="Home modifications",
+        caption="Plan accessibility upgrades or fall-prevention improvements.",
+        fields=[
+            {
+                "type": "select",
+                "label": "Project focus",
+                "options": [
+                    "Bathroom safety",
+                    "Ramps & entry",
+                    "Lighting",
+                    "Smart monitoring",
+                ],
+                "index": 0,
+                "key": "project_focus",
+            },
+            {
+                "columns": 2,
+                "items": [
+                    {
+                        "type": "number",
+                        "label": "Estimated one-time cost",
+                        "value": 4200.0,
+                        "step": 100.0,
+                        "key": "project_cost",
+                    },
+                    {
+                        "type": "select",
+                        "label": "Urgency",
+                        "options": ["Nice to have", "Recommended", "High priority"],
+                        "index": 2,
+                        "key": "project_urgency",
+                    },
+                ],
+            },
+            {
+                "type": "textarea",
+                "label": "Vendors or resources",
+                "value": "Local contractor quoted $4,200. VA grant eligibility TBD.",
+                "key": "project_vendors",
+            },
+        ],
+        metrics=[
+            {"label": "One-time upgrades", "value": format_currency(4200)},
+        ],
+        nav_buttons=[
+            {"label": "Skip", "type": "secondary", "key": "mods_skip"},
+            {"label": "Save & continue", "type": "primary", "key": "mods_continue"},
+        ],
+        helper_text="Track safety upgrades even if they're one-time purchases so loved ones know what's planned.",
+        callouts=[
+            {
+                "tone": "info",
+                "text": "Navi: Some VA programs reimburse bathroom safety upgrades. Flag in benefits if eligible.",
+            }
+        ],
+    )
+
+
+def render_cost_planner_estimate_summary() -> None:
+    start_container()
+    render_assessment_header("Guided Cost Plan", mode="Summary view")
+    st.subheader("Estimate summary")
+    st.caption("Review your monthly totals before confirming the plan.")
+
+    render_metrics(
+        [
+            {"label": "Monthly costs", "value": format_currency(7320)},
+            {"label": "Offsets", "value": format_currency(3250)},
+            {"label": "Net out-of-pocket", "value": format_currency(4070)},
+            {"label": "Runway (months)", "value": "11"},
+        ]
+    )
+
+    st.markdown(
+        """
+<table class="summary-table">
+  <thead>
+    <tr><th>Category</th><th class="amount">Monthly</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Housing & living</td><td class="amount">$3,200</td></tr>
+    <tr><td>In-home care</td><td class="amount">$4,520</td></tr>
+    <tr><td>Medical & daily aids</td><td class="amount">$400</td></tr>
+    <tr><td>Other items</td><td class="amount">$180</td></tr>
+    <tr><td>Offsets & benefits</td><td class="amount">−$3,250</td></tr>
+  </tbody>
+</table>
+""",
+        unsafe_allow_html=True,
+    )
+
+    render_wizard_help("Export your estimate as PDF/CSV or continue to confirmation to lock the plan for sharing.")
+    render_nav_buttons(
+        [
+            {"label": "Back to modules", "type": "secondary", "key": "summary_back"},
+            {"label": "Download", "type": "secondary", "key": "summary_download"},
+            {"label": "Continue", "type": "primary", "key": "summary_continue"},
+        ]
+    )
+    end_container()
+
+
+def render_cost_plan_confirm() -> None:
+    start_container()
+    render_assessment_header("Cost plan confirmation", mode="Final review")
+    st.subheader("Lock in your plan")
+    st.caption("Share the plan, export for professionals, or update the PFMA workflow.")
+
+    render_metrics(
+        [
+            {"label": "Monthly costs", "value": format_currency(7320)},
+            {"label": "Offsets", "value": format_currency(3250)},
+            {"label": "Net out-of-pocket", "value": format_currency(4070)},
+        ]
+    )
+
+    st.checkbox("Share with family hub", value=True, key="confirm_share_family")
+    st.checkbox("Send to professional navigator", value=False, key="confirm_share_pro")
+    st.checkbox("Trigger PFMA follow-up", value=True, key="confirm_pfma")
+
+    st.text_area(
+        "Next steps for the team",
+        value="Schedule a benefits review and confirm agency weekend rates.",
+        key="confirm_next_steps",
+    )
+
+    render_wizard_help("Completing confirmation stores a snapshot for CRM export and kicks off navigator tasks.")
+    render_nav_buttons(
+        [
+            {"label": "Back", "type": "secondary", "key": "confirm_back"},
+            {"label": "Share plan", "type": "primary", "key": "confirm_share"},
+            {"label": "Finish", "type": "primary", "key": "confirm_finish"},
+        ]
+    )
+    end_container()
+
+
+def render_cost_planner_skipped() -> None:
+    start_container()
+    render_assessment_header("Guided Cost Plan", mode="Follow-ups")
+    st.subheader("Modules to revisit")
+    st.caption("These steps were skipped or only partially completed.")
+
+    skipped_items = [
+        "Benefits & income — Add pension statement",
+        "Home modifications — Confirm vendor quotes",
+        "Notes & extras — Capture sibling commitments",
+    ]
+    for item in skipped_items:
+        st.markdown(f"<div class='wizard-suggestion wizard-suggestion-warn'>{item}</div>", unsafe_allow_html=True)
+
+    render_wizard_help("Finish these modules to unlock expert review and export options.")
+    render_nav_buttons(
+        [
+            {"label": "Return to modules", "type": "secondary", "key": "skipped_back"},
+            {"label": "Clear skips", "type": "primary", "key": "skipped_clear"},
+        ]
+    )
+    end_container()
+
+
+def render_cost_planner_evaluation() -> None:
+    start_container()
+    render_assessment_header("Expert review", mode="All flags")
+    st.subheader("Expert review")
+    st.caption("Navi checked your plan and found a few things to confirm.")
+
+    st.markdown(
+        "<div class='wizard-suggestion wizard-suggestion-info'>Hey, I'm Navi. Your plan is coming together—here are a few items to double-check.</div>",
+        unsafe_allow_html=True,
+    )
+    st.markdown(
+        "<div class='wizard-suggestion wizard-suggestion-warn'>Rx cost looks high for similar households. Could Medicare Part D bring it down?</div>",
+        unsafe_allow_html=True,
+    )
+    st.markdown(
+        "<div class='wizard-suggestion wizard-suggestion-critical'>Runway under 12 months. Explore VA Aid & Attendance in benefits.</div>",
+        unsafe_allow_html=True,
+    )
+
+    render_metrics(
+        [
+            {"label": "Monthly costs", "value": format_currency(7320)},
+            {"label": "Offsets", "value": format_currency(3250)},
+            {"label": "Net out-of-pocket", "value": format_currency(4070)},
+        ]
+    )
+
+    with st.expander("Decision log"):
+        st.write(
+            "- Recommendation: Assisted living with memory care support\n"
+            "- Medicaid short-circuit triggered\n"
+            "- Added custom transportation line item"
+        )
+
+    render_wizard_help("Resolve critical flags before sharing the plan with family or professionals.")
+    render_nav_buttons(
+        [
+            {"label": "Back to modules", "type": "secondary", "key": "evaluation_back"},
+            {"label": "Resolve flags", "type": "primary", "key": "evaluation_resolve"},
+            {"label": "Complete review", "type": "primary", "key": "evaluation_complete"},
+        ]
+    )
+    end_container()
+
+
+apply_global_styles()
+
+
+@dataclass
+class WireframePage:
+    key: str
+    label: str
+    description: str
+    render: Callable[[], None]
+
+
+WIREFRAME_PAGES: List[WireframePage] = [
+    WireframePage(
+        key="cost_planner",
+        label="Cost Planner (mode selector)",
+        description="Hero screen that offers Explore vs Plan modes.",
+        render=render_cost_planner_mode_selector,
+    ),
+    WireframePage(
+        key="cost_planner_qualifiers",
+        label="Cost Planner Qualifiers",
+        description="Optional pre-intake step for financial qualifiers and contributors.",
+        render=render_cost_planner_qualifiers,
+    ),
+    WireframePage(
+        key="cost_planner_estimate",
+        label="Cost Planner Estimate",
+        description="Initial intake selections before entering the module dashboard.",
+        render=render_cost_planner_estimate,
+    ),
+    WireframePage(
+        key="cost_planner_modules",
+        label="Cost Planner Modules",
+        description="Dashboard of module tiles showing progress and Navi priorities.",
+        render=render_cost_planner_modules,
+    ),
+    WireframePage(
+        key="cost_planner_housing",
+        label="Housing module",
+        description="Housing & living cost inputs using the module pattern.",
+        render=render_cost_planner_housing,
+    ),
+    WireframePage(
+        key="cost_planner_home_care",
+        label="Home care module",
+        description="Staffing and add-on costs for in-home care.",
+        render=render_cost_planner_home_care,
+    ),
+    WireframePage(
+        key="cost_planner_daily_aids",
+        label="Medical & daily aids module",
+        description="Recurring medical supplies, prescriptions, and transport.",
+        render=render_cost_planner_daily_aids,
+    ),
+    WireframePage(
+        key="cost_planner_benefits",
+        label="Benefits & income module",
+        description="Offsets and premium tracking.",
+        render=render_cost_planner_benefits,
+    ),
+    WireframePage(
+        key="cost_planner_freeform",
+        label="Notes & extras module",
+        description="Custom line items, debts, and planner notes.",
+        render=render_cost_planner_freeform,
+    ),
+    WireframePage(
+        key="cost_planner_mods",
+        label="Home modifications module",
+        description="Safety and accessibility projects.",
+        render=render_cost_planner_mods,
+    ),
+    WireframePage(
+        key="cost_planner_estimate_summary",
+        label="Estimate summary",
+        description="Roll-up of monthly totals, offsets, and categories.",
+        render=render_cost_planner_estimate_summary,
+    ),
+    WireframePage(
+        key="cost_plan_confirm",
+        label="Cost plan confirmation",
+        description="Final confirmation screen before exporting or sharing.",
+        render=render_cost_plan_confirm,
+    ),
+    WireframePage(
+        key="cost_planner_skipped",
+        label="Skipped modules",
+        description="Follow-up list for unfinished modules.",
+        render=render_cost_planner_skipped,
+    ),
+    WireframePage(
+        key="cost_planner_evaluation",
+        label="Expert review",
+        description="Navi's review flags and decision log.",
+        render=render_cost_planner_evaluation,
+    ),
+]
+
+
+PAGE_LOOKUP: Dict[str, WireframePage] = {page.key: page for page in WIREFRAME_PAGES}
+
+
+st.sidebar.header("Cost Planner wireframes")
+selected_key = st.sidebar.selectbox(
+    "Preview a page",
+    options=[page.key for page in WIREFRAME_PAGES],
+    format_func=lambda key: PAGE_LOOKUP[key].label,
+)
+
+selected_page = PAGE_LOOKUP[selected_key]
+st.sidebar.write(selected_page.description)
+
+selected_page.render()

--- a/docs/cost_planner_wireframe_alignment.md
+++ b/docs/cost_planner_wireframe_alignment.md
@@ -1,0 +1,38 @@
+# Cost Planner Wireframe Alignment
+
+This document maps the Streamlit wireframes in `cost_planner_wireframes.py` to the existing Cost Planner pages so the team can see where the new visual design overlaps with production flows.
+
+## Wireframe coverage at a glance
+
+| Wireframe section | Intended production page | Notes |
+| --- | --- | --- |
+| Entry mode selector (Page 1) | `pages/cost_planner.py` | Wireframe adds header/hero polish to the existing mode selection that seeds `care_context` and routes to the estimate flow.【F:cost_planner_wireframes.py†L61-L107】【F:pages/cost_planner.py†L9-L55】 |
+| Qualifiers (Page 2) | *(No one-to-one page)* | Current flow jumps from the mode selector into `cost_planner_estimate.py`, which pulls qualifier answers from session state instead of presenting a dedicated screen. Implementing the wireframe would require adding a new qualifiers step before that page.【F:cost_planner_wireframes.py†L109-L170】【F:pages/cost_planner_estimate.py†L22-L84】 |
+| Housing module (Page 3) | `pages/cost_planner_housing.py` | The housing wireframe mirrors the production inputs; both capture base rent, utilities, and maintenance before showing the subtotal metric.【F:cost_planner_wireframes.py†L172-L238】【F:pages/cost_planner_housing.py†L19-L76】 |
+| Expert review (Page 4) | `pages/cost_planner_evaluation.py` | The expert review wireframe matches the existing evaluation drawer that builds expert flags, shows Navi copy, and surfaces metrics for monthly costs and offsets.【F:cost_planner_wireframes.py†L240-L290】【F:pages/cost_planner_evaluation.py†L21-L76】 |
+
+## Page-by-page evaluation
+
+The following table covers every page whose filename starts with `cost_plan` or `cost_planner`, summarising what it currently does and how (or if) the new wireframes apply.
+
+| Page | Current behaviour | Wireframe relationship |
+| --- | --- | --- |
+| `pages/cost_plan_confirm.py` | Final confirmation screen with metrics, CRM export, and PFMA handoff triggers.【F:pages/cost_plan_confirm.py†L22-L68】 | Not represented in the wireframes; would need bespoke styling if the new visual language is adopted. |
+| `pages/cost_planner.py` | Establishes session defaults, offers **Estimate Costs** vs **Plan Costs**, and routes to the estimate entry page or hub.【F:pages/cost_planner.py†L9-L53】 | Direct match for wireframe Page&nbsp;1. Adopt hero/header styles from the wireframe for consistency.【F:cost_planner_wireframes.py†L61-L107】 |
+| `pages/cost_planner_benefits.py` | Captures insurance premiums, income, and benefit offsets with conditional fields based on qualifiers, then updates the offsets subtotal.【F:pages/cost_planner_benefits.py†L26-L142】 | Not modelled in the wireframes; would follow the module styling introduced elsewhere if we extend the new visuals. |
+| `pages/cost_planner_daily_aids.py` | Records prescription, supply, and transportation costs while surfacing chronic condition guidance, then updates the medical subtotal.【F:pages/cost_planner_daily_aids.py†L18-L70】 | Not covered in the wireframes; should mirror the Housing module layout if we want visual parity. |
+| `pages/cost_planner_estimate.py` | Main entry form that confirms planner mode, household structure, captures liquid assets for planning mode, and surfaces running totals.【F:pages/cost_planner_estimate.py†L28-L129】 | Wireframe Page&nbsp;2 would slot before this page if we introduce a dedicated qualifier step; otherwise this page keeps the existing copy/controls. |
+| `pages/cost_planner_estimate_summary.py` | Presents totals, category breakdown, custom items, and export options (PDF/CSV/JSON) before routing to confirmation.【F:pages/cost_planner_estimate_summary.py†L25-L110】 | Outside the four wireframes; apply the new header/metric styling separately if desired. |
+| `pages/cost_planner_evaluation.py` | Builds expert flags from gaps between Guided Care Plan data and inputs, lists decision log entries, and shows key metrics.【F:pages/cost_planner_evaluation.py†L26-L76】 | Aligns with wireframe Page&nbsp;4; primary gap is swapping placeholder Navi copy for actual flag output. |
+| `pages/cost_planner_freeform.py` | Handles debts, miscellaneous expenses, custom line items, and planner notes before routing to expert review.【F:pages/cost_planner_freeform.py†L17-L101】 | Not depicted in the wireframes; consider reusing the housing-style layout for consistency. |
+| `pages/cost_planner_home_care.py` | Collects staffing, add-ons, supplemental services, and second-person support while reflecting Guided Care Plan recommendations.【F:pages/cost_planner_home_care.py†L27-L94】 | Not in the wireframes; new styling would mirror other module pages. |
+| `pages/cost_planner_housing.py` | Captures housing costs with qualifier-driven helper text and updates the housing subtotal metric.【F:pages/cost_planner_housing.py†L19-L76】 | Directly modelled by wireframe Page&nbsp;3; only visual polish differs.【F:cost_planner_wireframes.py†L172-L238】 |
+| `pages/cost_planner_mods.py` | Prototype age-in-place upgrade chooser with static yes/no buttons and no cost hooks yet.【F:pages/cost_planner_mods.py†L31-L58】 | Wireframes do not cover this concept; needs bespoke design work. |
+| `pages/cost_planner_modules.py` | Presents module tiles with status, linking into the estimate/housing/care/benefits flows or back to mode selection.【F:pages/cost_planner_modules.py†L21-L74】 | Not referenced in the wireframe bundle; retains dashboard tile layout unless redesigned. |
+| `pages/cost_planner_skipped.py` | Stub screen listing skipped modules with a CTA to revisit them.【F:pages/cost_planner_skipped.py†L31-L50】 | Not covered by the wireframes; consider applying the same hero and tile styling if kept. |
+
+## Key takeaways
+
+- Only the entry mode, housing, and expert review pages have direct counterparts in the provided wireframes; the qualifiers concept is new and would require an additional step in the production flow.
+- Module-specific drawers (care, medical, benefits, freeform, upgrades) will need tailored design updates if the TurboTax-inspired styling becomes the standard.
+- Downstream summary and confirmation pages are outside the scope of the wireframes and should be addressed separately if we want a unified look and feel.

--- a/pages/cost_planner.py
+++ b/pages/cost_planner.py
@@ -1,55 +1,68 @@
 import streamlit as st
-from ui.theme import inject_theme
+
+from ui.cost_planner_template import (
+    NavButton,
+    apply_cost_planner_theme,
+    cost_planner_page_container,
+    render_app_header,
+    render_nav_buttons,
+    render_wizard_help,
+    render_wizard_hero,
+)
 
 
-inject_theme()
-st.markdown('<div class="sn-scope dashboard">', unsafe_allow_html=True)
+apply_cost_planner_theme()
 
-
-if 'care_context' not in st.session_state:
+if "care_context" not in st.session_state:
     st.session_state.care_context = {
-        'gcp_answers': {},
-        'decision_trace': [],
-        'planning_mode': 'estimating',
-        'care_flags': {},
-        'person_name': 'Your Loved One',
+        "gcp_answers": {},
+        "decision_trace": [],
+        "planning_mode": "estimating",
+        "care_flags": {},
+        "person_name": "Your Loved One",
     }
 
 ctx = st.session_state.care_context
-person_name = ctx.get('person_name', 'Your Loved One')
+person_name = ctx.get("person_name", "Your Loved One")
 
-st.title(f"Cost Planner for {person_name}")
-st.caption("Choose the level of detail that fits your needs right now.")
 
-st.markdown(
+with cost_planner_page_container():
+    render_app_header()
+    render_wizard_hero(
+        f"Cost Planner for {person_name}",
+        "Choose the level of detail that fits your needs right now.",
+    )
+
+    st.markdown(
+        """
+Families can start light and go deeper when they're ready. Pick the path
+that best fits the decisions you're making today. You can always return
+to switch modes later.
+
+- **Estimate Costs** — quick, high-level monthly estimate using a few
+  selections.
+- **Plan Costs** — full planning workflow with modules, offsets, and
+  runway tracking.
 """
-Not everyone needs the same level of detail. Some families just want a ballpark idea of what care might cost, while others
-want a fully personalized view based on their situation.
+    )
 
-- **Estimate Costs**  
-  Quick, high-level monthly estimate using a few selections. You can refine later.
+    render_wizard_help(
+        "You can switch between estimating and planning. We'll remember your progress in each path.",
+    )
 
-- **Plan Costs**  
-  Full, personalized planning with detailed modules. Best if you're ready to go deeper.
-"""
-)
+    clicked = render_nav_buttons(
+        [
+            NavButton("Estimate Costs", "cp_estimate", type="primary"),
+            NavButton("Plan Costs", "cp_plan", type="primary"),
+            NavButton("Back to Hub", "cp_back_hub"),
+        ]
+    )
 
-st.markdown('---')
-
-col1, col2, col3 = st.columns([1,1,1])
-
-with col1:
-    if st.button("Estimate Costs", key="cp_estimate"):
-        ctx['planning_mode'] = 'estimating'
-        st.switch_page('pages/cost_planner_estimate.py')
-
-with col2:
-    if st.button("Plan Costs", key="cp_plan"):
-        ctx['planning_mode'] = 'planning'
-        st.switch_page('pages/cost_planner_estimate.py')
-
-with col3:
-    if st.button("Back to Hub", key="cp_back_hub"):
-        st.switch_page('pages/hub.py')
-
-st.markdown('</div>', unsafe_allow_html=True)
+    if clicked == "cp_estimate":
+        ctx["planning_mode"] = "estimating"
+        st.switch_page("pages/cost_planner_estimate.py")
+    elif clicked == "cp_plan":
+        ctx["planning_mode"] = "planning"
+        st.switch_page("pages/cost_planner_estimate.py")
+    elif clicked == "cp_back_hub":
+        st.switch_page("pages/hub.py")

--- a/pages/cost_planner_benefits.py
+++ b/pages/cost_planner_benefits.py
@@ -1,21 +1,30 @@
 """Insurance costs and benefit offsets drawer."""
 from __future__ import annotations
-from ui.theme import inject_theme
 
 import streamlit as st
 
 from cost_planner_shared import (
-
     ensure_core_state,
     format_currency,
     get_numeric,
     recompute_costs,
     set_numeric,
-
-
 )
-inject_theme()
-st.markdown('<div class="sn-scope dashboard">', unsafe_allow_html=True)
+from ui.cost_planner_template import (
+    Metric,
+    NavButton,
+    apply_cost_planner_theme,
+    cost_planner_page_container,
+    render_app_header,
+    render_metrics,
+    render_nav_buttons,
+    render_suggestion,
+    render_wizard_help,
+    render_wizard_hero,
+)
+
+
+apply_cost_planner_theme()
 
 
 ensure_core_state()
@@ -23,122 +32,133 @@ cp = st.session_state["cost_planner"]
 aud = st.session_state["audiencing"]
 quals = aud.get("qualifiers", {})
 
-st.title("Insurance & benefit offsets")
-st.caption("Log insurance premiums and the income or benefits that offset monthly costs.")
 
-st.subheader("Insurance premiums")
-col_1, col_2, col_3 = st.columns(3)
-with col_1:
-    health = st.number_input(
-        "Health insurance premiums",
-        min_value=0.0,
-        step=25.0,
-        value=float(get_numeric("insurance_health")),
-        help="Medicare, Advantage, Medigap, or supplemental health premiums.",
+with cost_planner_page_container():
+    render_app_header()
+    render_wizard_hero(
+        "Insurance & benefit offsets",
+        "Log insurance premiums and the income or benefits that offset monthly costs.",
     )
-    set_numeric("insurance_health", health)
-with col_2:
-    ltc = st.number_input(
-        "Long-term care insurance premiums",
-        min_value=0.0,
-        step=25.0,
-        value=float(get_numeric("insurance_ltc")),
-        help="Monthly payment due for active LTC policies.",
-    )
-    set_numeric("insurance_ltc", ltc)
-with col_3:
-    other_ins = st.number_input(
-        "Other insurance premiums",
-        min_value=0.0,
-        step=25.0,
-        value=float(get_numeric("insurance_other")),
-        help="Dental, vision, life, umbrella, or other recurring premiums.",
-    )
-    set_numeric("insurance_other", other_ins)
 
-st.subheader("Income & benefits")
-col_income1, col_income2 = st.columns(2)
-with col_income1:
-    inc_ss = st.number_input(
-        "Social Security income",
-        min_value=0.0,
-        step=50.0,
-        value=float(get_numeric("offset_ss_income")),
-    )
-    set_numeric("offset_ss_income", inc_ss)
-    inc_pension = st.number_input(
-        "Pension income",
-        min_value=0.0,
-        step=50.0,
-        value=float(get_numeric("offset_pension_income")),
-    )
-    set_numeric("offset_pension_income", inc_pension)
-with col_income2:
-    inc_annuity = st.number_input(
-        "Annuity income",
-        min_value=0.0,
-        step=50.0,
-        value=float(get_numeric("offset_annuity_income")),
-    )
-    set_numeric("offset_annuity_income", inc_annuity)
-    inc_other = st.number_input(
-        "Other recurring income",
-        min_value=0.0,
-        step=50.0,
-        value=float(get_numeric("offset_other_income")),
-        help="Family contributions, trust distributions, or gig income.",
-    )
-    set_numeric("offset_other_income", inc_other)
-
-col_benefit1, col_benefit2, col_benefit3 = st.columns(3)
-with col_benefit1:
-    if quals.get("is_veteran"):
-        va = st.number_input(
-            "VA benefits",
+    st.subheader("Insurance premiums")
+    col_1, col_2, col_3 = st.columns(3)
+    with col_1:
+        health = st.number_input(
+            "Health insurance premiums",
             min_value=0.0,
             step=25.0,
-            value=float(get_numeric("offset_va_benefits")),
-            help="VA Aid & Attendance or other VA programs applied to care costs.",
+            value=float(get_numeric("insurance_health")),
+            help="Medicare, Advantage, Medigap, or supplemental health premiums.",
         )
-        set_numeric("offset_va_benefits", va)
-    else:
-        set_numeric("offset_va_benefits", 0.0)
-        st.caption("VA benefits hidden - not eligible per Audiencing.")
-with col_benefit2:
-    medicaid = st.number_input(
-        "Medicaid coverage",
-        min_value=0.0,
-        step=25.0,
-        value=float(get_numeric("offset_medicaid_benefits")),
-        help="State Medicaid offsets covering monthly care expenses.",
-        disabled=not quals.get("on_medicaid"),
+        set_numeric("insurance_health", health)
+    with col_2:
+        ltc = st.number_input(
+            "Long-term care insurance premiums",
+            min_value=0.0,
+            step=25.0,
+            value=float(get_numeric("insurance_ltc")),
+            help="Monthly payment due for active LTC policies.",
+        )
+        set_numeric("insurance_ltc", ltc)
+    with col_3:
+        other_ins = st.number_input(
+            "Other insurance premiums",
+            min_value=0.0,
+            step=25.0,
+            value=float(get_numeric("insurance_other")),
+            help="Dental, vision, life, umbrella, or other recurring premiums.",
+        )
+        set_numeric("insurance_other", other_ins)
+
+    st.subheader("Income & benefits")
+    col_income1, col_income2 = st.columns(2)
+    with col_income1:
+        inc_ss = st.number_input(
+            "Social Security income",
+            min_value=0.0,
+            step=50.0,
+            value=float(get_numeric("offset_ss_income")),
+        )
+        set_numeric("offset_ss_income", inc_ss)
+        inc_pension = st.number_input(
+            "Pension income",
+            min_value=0.0,
+            step=50.0,
+            value=float(get_numeric("offset_pension_income")),
+        )
+        set_numeric("offset_pension_income", inc_pension)
+    with col_income2:
+        inc_annuity = st.number_input(
+            "Annuity income",
+            min_value=0.0,
+            step=50.0,
+            value=float(get_numeric("offset_annuity_income")),
+        )
+        set_numeric("offset_annuity_income", inc_annuity)
+        inc_other = st.number_input(
+            "Other recurring income",
+            min_value=0.0,
+            step=50.0,
+            value=float(get_numeric("offset_other_income")),
+            help="Family contributions, trust distributions, or gig income.",
+        )
+        set_numeric("offset_other_income", inc_other)
+
+    col_benefit1, col_benefit2, col_benefit3 = st.columns(3)
+    with col_benefit1:
+        if quals.get("is_veteran"):
+            va = st.number_input(
+                "VA benefits",
+                min_value=0.0,
+                step=25.0,
+                value=float(get_numeric("offset_va_benefits")),
+                help="VA Aid & Attendance or other VA programs applied to care costs.",
+            )
+            set_numeric("offset_va_benefits", va)
+        else:
+            set_numeric("offset_va_benefits", 0.0)
+            render_suggestion("VA benefits hidden – not eligible per Audiencing.", tone="warn")
+    with col_benefit2:
+        medicaid = st.number_input(
+            "Medicaid coverage",
+            min_value=0.0,
+            step=25.0,
+            value=float(get_numeric("offset_medicaid_benefits")),
+            help="State Medicaid offsets covering monthly care expenses.",
+            disabled=not quals.get("on_medicaid"),
+        )
+        set_numeric("offset_medicaid_benefits", medicaid if quals.get("on_medicaid") else 0.0)
+    with col_benefit3:
+        ltc_payout = st.number_input(
+            "LTC insurance payouts",
+            min_value=0.0,
+            step=25.0,
+            value=float(get_numeric("offset_ltc_benefits")),
+            help="Monthly payout from LTC policy benefit triggers.",
+        )
+        set_numeric("offset_ltc_benefits", ltc_payout)
+
+    recompute_costs()
+
+    render_metrics(
+        [
+            Metric("Offsets subtotal", format_currency(cp["subtotals"]["offsets"]))
+        ]
     )
-    set_numeric("offset_medicaid_benefits", medicaid if quals.get("on_medicaid") else 0.0)
-with col_benefit3:
-    ltc_payout = st.number_input(
-        "LTC insurance payouts",
-        min_value=0.0,
-        step=25.0,
-        value=float(get_numeric("offset_ltc_benefits")),
-        help="Monthly payout from LTC policy benefit triggers.",
+
+    render_wizard_help("Track both premiums you pay and the income that offsets monthly expenses.")
+
+    clicked = render_nav_buttons(
+        [
+            NavButton("Return to Hub", "benefits_back_hub"),
+            NavButton("Back: Medical", "benefits_back_medical"),
+            NavButton("Next: Debts & Other", "benefits_next_debts", type="primary"),
+        ]
     )
-    set_numeric("offset_ltc_benefits", ltc_payout)
 
-recompute_costs()
-
-st.metric("Offsets subtotal", format_currency(cp["subtotals"]["offsets"]))
-
-st.markdown("---")
-
-col_hub, col_back, col_next = st.columns([1, 1, 1])
-with col_hub:
-    if st.button("Return to Hub", type="secondary"):
+    if clicked == "benefits_back_hub":
         st.switch_page("pages/hub.py")
-with col_back:
-    if st.button("Back: Medical"):
+    elif clicked == "benefits_back_medical":
         st.switch_page("pages/cost_planner_daily_aids.py")
-with col_next:
-    if st.button("Next: Debts & Other", type="primary"):
+    elif clicked == "benefits_next_debts":
         st.switch_page("pages/cost_planner_freeform.py")
-
-st.markdown('</div>', unsafe_allow_html=True)

--- a/pages/cost_planner_daily_aids.py
+++ b/pages/cost_planner_daily_aids.py
@@ -1,72 +1,93 @@
 """Medical and daily aids drawer."""
 from __future__ import annotations
-from ui.theme import inject_theme
 
 import streamlit as st
 
 from cost_planner_shared import ensure_core_state, format_currency, get_numeric, recompute_costs, set_numeric
+from ui.cost_planner_template import (
+    Metric,
+    NavButton,
+    apply_cost_planner_theme,
+    cost_planner_page_container,
+    render_app_header,
+    render_metrics,
+    render_nav_buttons,
+    render_suggestion,
+    render_wizard_help,
+    render_wizard_hero,
+)
 
 
-inject_theme()
-st.markdown('<div class="sn-scope dashboard">', unsafe_allow_html=True)
+apply_cost_planner_theme()
 
 
 ensure_core_state()
 cp = st.session_state["cost_planner"]
 gcp = st.session_state.get("gcp", {})
 
-st.title("Medical and daily living aids")
-st.caption("Capture medication costs, supplies, and transport to appointments.")
 
-chronic = gcp.get("chronic_conditions", [])
-if chronic:
-    st.info(
-        "Chronic conditions noted in the Guided Care Plan: " + ", ".join(chronic),
-        icon="🧬",
+with cost_planner_page_container():
+    render_app_header()
+    render_wizard_hero(
+        "Medical and daily living aids",
+        "Capture medication costs, supplies, and transport to appointments.",
     )
 
-rx = st.number_input(
-    "Prescription medications",
-    min_value=0.0,
-    step=25.0,
-    value=float(get_numeric("medical_prescriptions")),
-    help="Monthly prescription spending across retail and mail order.",
-)
-set_numeric("medical_prescriptions", rx)
+    chronic = gcp.get("chronic_conditions", [])
+    if chronic:
+        render_suggestion(
+            "Chronic conditions noted in the Guided Care Plan: " + ", ".join(chronic),
+            tone="info",
+        )
 
-supplies = st.number_input(
-    "Medical supplies & equipment",
-    min_value=0.0,
-    step=25.0,
-    value=float(get_numeric("medical_supplies")),
-    help="Incontinence products, DME rentals, batteries, and similar.",
-)
-set_numeric("medical_supplies", supplies)
+    rx = st.number_input(
+        "Prescription medications",
+        min_value=0.0,
+        step=25.0,
+        value=float(get_numeric("medical_prescriptions")),
+        help="Monthly prescription spending across retail and mail order.",
+    )
+    set_numeric("medical_prescriptions", rx)
 
-transport = st.number_input(
-    "Medical transportation",
-    min_value=0.0,
-    step=25.0,
-    value=float(get_numeric("medical_transport")),
-    help="Ambulance subscriptions, paratransit, or rides to medical appointments.",
-)
-set_numeric("medical_transport", transport)
+    supplies = st.number_input(
+        "Medical supplies & equipment",
+        min_value=0.0,
+        step=25.0,
+        value=float(get_numeric("medical_supplies")),
+        help="Incontinence products, DME rentals, batteries, and similar.",
+    )
+    set_numeric("medical_supplies", supplies)
 
-recompute_costs()
+    transport = st.number_input(
+        "Medical transportation",
+        min_value=0.0,
+        step=25.0,
+        value=float(get_numeric("medical_transport")),
+        help="Ambulance subscriptions, paratransit, or rides to medical appointments.",
+    )
+    set_numeric("medical_transport", transport)
 
-st.metric("Medical subtotal", format_currency(cp["subtotals"]["medical"]))
+    recompute_costs()
 
-st.markdown("---")
+    render_metrics(
+        [
+            Metric("Medical subtotal", format_currency(cp["subtotals"]["medical"]))
+        ]
+    )
 
-col_hub, col_back, col_next = st.columns([1, 1, 1])
-with col_hub:
-    if st.button("Return to Hub", type="secondary"):
+    render_wizard_help("Capture recurring prescriptions separately from one-time equipment purchases.")
+
+    clicked = render_nav_buttons(
+        [
+            NavButton("Return to Hub", "medical_back_hub"),
+            NavButton("Back: Care", "medical_back_care"),
+            NavButton("Next: Insurance", "medical_next_insurance", type="primary"),
+        ]
+    )
+
+    if clicked == "medical_back_hub":
         st.switch_page("pages/hub.py")
-with col_back:
-    if st.button("Back: Care"):
+    elif clicked == "medical_back_care":
         st.switch_page("pages/cost_planner_home_care.py")
-with col_next:
-    if st.button("Next: Insurance", type="primary"):
+    elif clicked == "medical_next_insurance":
         st.switch_page("pages/cost_planner_benefits.py")
-
-st.markdown('</div>', unsafe_allow_html=True)

--- a/pages/cost_planner_estimate.py
+++ b/pages/cost_planner_estimate.py
@@ -1,23 +1,30 @@
 """Cost Planner entry: establish mode, household, and audience context."""
 from __future__ import annotations
-from ui.theme import inject_theme
 
 import streamlit as st
 
 from cost_planner_shared import (
-
     audiencing_badges,
     ensure_core_state,
     format_currency,
     get_numeric,
     recompute_costs,
     set_numeric,
-
-
 )
-inject_theme()
-st.markdown('<div class="sn-scope dashboard">', unsafe_allow_html=True)
+from ui.cost_planner_template import (
+    Metric,
+    NavButton,
+    apply_cost_planner_theme,
+    cost_planner_page_container,
+    render_app_header,
+    render_metrics,
+    render_nav_buttons,
+    render_wizard_help,
+    render_wizard_hero,
+)
 
+
+apply_cost_planner_theme()
 
 ensure_core_state()
 cp = st.session_state["cost_planner"]
@@ -25,107 +32,115 @@ aud = st.session_state["audiencing"]
 gcp = st.session_state.get("gcp", {})
 qualifiers = aud.get("qualifiers", {})
 
-st.title("Cost Planner")
-st.caption("TurboTax-style walkthrough to understand monthly costs, offsets, and runway.")
 
-entry, badges = audiencing_badges()
-alert_lines = [
-    f"Planning for **{entry}** audience.",
-]
-if badges:
-    alert_lines.append(" * ".join(badges))
-st.info(" \n".join(alert_lines))
-
-if qualifiers.get("on_medicaid"):
-    st.warning(
-        "Medicaid coverage detected. We'll default costs to the Medicaid payment context and log a short-circuit entry.",
-        icon="💡",
+with cost_planner_page_container():
+    render_app_header()
+    render_wizard_hero(
+        "Cost Planner",
+        "TurboTax-style walkthrough to understand monthly costs, offsets, and runway.",
     )
 
-recommended = gcp.get("recommended_setting")
-if recommended:
-    st.success(
-        f"Guided Care Plan recommends **{recommended.title()}** with {gcp.get('care_intensity', 'unknown')} care intensity.",
-        icon="🧭",
-    )
+    entry, badges = audiencing_badges()
+    alert_lines = [
+        f"Planning for **{entry}** audience.",
+    ]
+    if badges:
+        alert_lines.append(" * ".join(badges))
+    st.info(" \n".join(alert_lines))
 
-col_mode, col_household = st.columns([2, 2])
-with col_mode:
-    mode_label = {
-        "tinkering": "I'm exploring rough numbers",
-        "planning": "I need a real plan with runway",
-    }
-    mode_choice = st.radio(
-        "Planner mode",
-        options=["tinkering", "planning"],
-        format_func=lambda val: mode_label[val],
-        index=["tinkering", "planning"].index(cp.get("mode", "tinkering")),
-        horizontal=False,
-    )
-    if mode_choice != cp.get("mode"):
-        cp["mode"] = mode_choice
+    if qualifiers.get("on_medicaid"):
+        st.warning(
+            "Medicaid coverage detected. We'll default costs to the Medicaid payment context and log a short-circuit entry.",
+            icon="💡",
+        )
 
-with col_household:
-    household_label = {
-        "single": "Single household",
-        "split": "Split household",
-    }
-    disable_partner = not qualifiers.get("has_partner")
-    household_choice = st.radio(
-        "Household",
-        options=["single", "split"],
-        format_func=lambda val: household_label[val],
-        index=["single", "split"].index(cp.get("household", "single")),
-        horizontal=False,
-        disabled=disable_partner,
-        help="Partners must be enabled in Audiencing to plan for a split household." if disable_partner else None,
-    )
-    cp["household"] = household_choice if not disable_partner else "single"
+    recommended = gcp.get("recommended_setting")
+    if recommended:
+        st.success(
+            f"Guided Care Plan recommends **{recommended.title()}** with {gcp.get('care_intensity', 'unknown')} care intensity.",
+            icon="🧭",
+        )
 
-st.markdown("---")
-
-if cp["mode"] == "planning":
-    assets_default = get_numeric("assets_total")
-    assets_value = st.number_input(
-        "Liquid assets available for care",
-        min_value=0.0,
-        step=500.0,
-        value=float(assets_default),
-        help="Enter savings that could be used to cover care. We'll calculate runway based on net out-of-pocket.",
-    )
-    set_numeric("assets_total", assets_value)
-else:
-    set_numeric("assets_total", 0.0)
-
-recompute_costs()
-
-subtotals = cp["subtotals"]
-summary_cols = st.columns(3)
-summary_cols[0].metric("Monthly costs", format_currency(cp["monthly_total"]))
-summary_cols[1].metric("Offsets", format_currency(subtotals["offsets"]))
-summary_cols[2].metric("Net out-of-pocket", format_currency(cp["net_out_of_pocket"]))
-
-st.markdown("---")
-
-with st.expander("Debug: Cost Planner session state", expanded=False):
-    st.json(
-        {
-            "mode": cp["mode"],
-            "household": cp["household"],
-            "audiencing": aud,
-            "gcp": gcp,
-            "inputs": cp["inputs"],
+    col_mode, col_household = st.columns([2, 2])
+    with col_mode:
+        mode_label = {
+            "tinkering": "I'm exploring rough numbers",
+            "planning": "I need a real plan with runway",
         }
+        mode_choice = st.radio(
+            "Planner mode",
+            options=["tinkering", "planning"],
+            format_func=lambda val: mode_label[val],
+            index=["tinkering", "planning"].index(cp.get("mode", "tinkering")),
+            horizontal=False,
+        )
+        if mode_choice != cp.get("mode"):
+            cp["mode"] = mode_choice
+
+    with col_household:
+        household_label = {
+            "single": "Single household",
+            "split": "Split household",
+        }
+        disable_partner = not qualifiers.get("has_partner")
+        household_choice = st.radio(
+            "Household",
+            options=["single", "split"],
+            format_func=lambda val: household_label[val],
+            index=["single", "split"].index(cp.get("household", "single")),
+            horizontal=False,
+            disabled=disable_partner,
+            help="Partners must be enabled in Audiencing to plan for a split household." if disable_partner else None,
+        )
+        cp["household"] = household_choice if not disable_partner else "single"
+
+    if cp["mode"] == "planning":
+        assets_default = get_numeric("assets_total")
+        assets_value = st.number_input(
+            "Liquid assets available for care",
+            min_value=0.0,
+            step=500.0,
+            value=float(assets_default),
+            help="Enter savings that could be used to cover care. We'll calculate runway based on net out-of-pocket.",
+        )
+        set_numeric("assets_total", assets_value)
+    else:
+        set_numeric("assets_total", 0.0)
+
+    recompute_costs()
+
+    subtotals = cp["subtotals"]
+    render_metrics(
+        [
+            Metric("Monthly costs", format_currency(cp["monthly_total"])),
+            Metric("Offsets", format_currency(subtotals["offsets"])),
+            Metric("Net out-of-pocket", format_currency(cp["net_out_of_pocket"]))
+        ]
     )
 
-st.markdown("---")
+    render_wizard_help(
+        "Use estimating to get oriented, or planning mode to unlock runway and offset tracking.",
+    )
 
-col_left, col_right = st.columns(2)
-with col_left:
-    if st.button("Return to Hub", type="secondary"):
+    with st.expander("Debug: Cost Planner session state", expanded=False):
+        st.json(
+            {
+                "mode": cp["mode"],
+                "household": cp["household"],
+                "audiencing": aud,
+                "gcp": gcp,
+                "inputs": cp["inputs"],
+            }
+        )
+
+    clicked = render_nav_buttons(
+        [
+            NavButton("Return to Hub", "cp_estimate_back_hub"),
+            NavButton("Start Housing", "cp_estimate_next", type="primary"),
+        ]
+    )
+
+    if clicked == "cp_estimate_back_hub":
         st.switch_page("pages/hub.py")
-with col_right:
-    if st.button("Start Housing", type="primary"):
+    elif clicked == "cp_estimate_next":
         st.switch_page("pages/cost_planner_housing.py")
-
-st.markdown('</div>', unsafe_allow_html=True)

--- a/pages/cost_planner_estimate_summary.py
+++ b/pages/cost_planner_estimate_summary.py
@@ -1,6 +1,5 @@
 """Summary, runway, and exports for the Cost Planner."""
 from __future__ import annotations
-from ui.theme import inject_theme
 
 import csv
 import io
@@ -9,10 +8,20 @@ import json
 import streamlit as st
 
 from cost_planner_shared import ensure_core_state, format_currency, recompute_costs
+from ui.cost_planner_template import (
+    Metric,
+    NavButton,
+    apply_cost_planner_theme,
+    cost_planner_page_container,
+    render_app_header,
+    render_metrics,
+    render_nav_buttons,
+    render_wizard_help,
+    render_wizard_hero,
+)
 
 
-inject_theme()
-st.markdown('<div class="sn-scope dashboard">', unsafe_allow_html=True)
+apply_cost_planner_theme()
 
 
 ensure_core_state()
@@ -22,91 +31,111 @@ gcp_state = st.session_state.get("gcp", {})
 
 recompute_costs()
 
-st.title("Cost Planner summary & exports")
-st.caption("Review totals, runway, and export everything for advisors or CRM.")
 
-summary_cols = st.columns(4)
-summary_cols[0].metric("Monthly costs", format_currency(cp["monthly_total"]))
-summary_cols[1].metric("Offsets", format_currency(cp["subtotals"]["offsets"]))
-summary_cols[2].metric("Net out-of-pocket", format_currency(cp["net_out_of_pocket"]))
-if cp.get("runway_months") is not None:
-    summary_cols[3].metric("Runway", f"{cp['runway_months']:.1f} months")
-else:
-    summary_cols[3].metric("Runway", "-")
+with cost_planner_page_container():
+    render_app_header()
+    render_wizard_hero(
+        "Cost Planner summary & exports",
+        "Review totals, runway, and export everything for advisors or CRM.",
+    )
 
-st.subheader("Category breakdown")
-breakdown_rows = []
-for key, label in [
-    ("housing", "Housing"),
-    ("care", "Care"),
-    ("medical", "Medical"),
-    ("insurance", "Insurance"),
-    ("debts", "Debts"),
-    ("other", "Other"),
-    ("offsets", "Offsets"),
-]:
-    breakdown_rows.append({"Category": label, "Monthly": cp["subtotals"][key]})
-st.dataframe(breakdown_rows, use_container_width=True, hide_index=True)
+    metrics = [
+        Metric("Monthly costs", format_currency(cp["monthly_total"])),
+        Metric("Offsets", format_currency(cp["subtotals"]["offsets"]))
+    ]
+    metrics.append(Metric("Net out-of-pocket", format_currency(cp["net_out_of_pocket"])))
+    runway_value = f"{cp['runway_months']:.1f} months" if cp.get("runway_months") is not None else "-"
+    metrics.append(Metric("Runway", runway_value))
+    render_metrics(metrics)
 
-if cp.get("custom_line_items"):
-    st.subheader("Custom line items")
-    for item in cp["custom_line_items"]:
-        st.write(f"* {item['label']}: {format_currency(item['amount'])}")
+    st.subheader("Category breakdown")
+    breakdown_rows = []
+    for key, label in [
+        ("housing", "Housing"),
+        ("care", "Care"),
+        ("medical", "Medical"),
+        ("insurance", "Insurance"),
+        ("debts", "Debts"),
+        ("other", "Other"),
+        ("offsets", "Offsets"),
+    ]:
+        breakdown_rows.append({"Category": label, "Monthly": cp["subtotals"][key]})
+    st.dataframe(breakdown_rows, use_container_width=True, hide_index=True)
 
-if cp.get("notes"):
-    st.info(cp["notes"], icon="📝")
+    if cp.get("custom_line_items"):
+        st.subheader("Custom line items")
+        for item in cp["custom_line_items"]:
+            st.write(f"* {item['label']}: {format_currency(item['amount'])}")
 
-snapshot = {
-    "audiencing": aud_snapshot,
-    "gcp": gcp_state,
-    "cost_planner": cp["snapshot_for_crm"],
-}
+    if cp.get("notes"):
+        render_wizard_help(cp["notes"])
 
-st.subheader("Exports")
-json_bytes = json.dumps(snapshot, indent=2).encode("utf-8")
+    snapshot = {
+        "audiencing": aud_snapshot,
+        "gcp": gcp_state,
+        "cost_planner": cp["snapshot_for_crm"],
+    }
 
-csv_buffer = io.StringIO()
-csv_writer = csv.writer(csv_buffer)
-csv_writer.writerow(["category", "amount"])
-for row in breakdown_rows:
-    csv_writer.writerow([row["Category"], row["Monthly"]])
-csv_writer.writerow(["Net out-of-pocket", cp["net_out_of_pocket"]])
+    st.subheader("Exports")
+    json_bytes = json.dumps(snapshot, indent=2).encode("utf-8")
 
-pdf_lines = [
-    "Senior Navigator Cost Planner Summary",
-    f"Monthly costs: {cp['monthly_total']:.2f}",
-    f"Offsets: {cp['subtotals']['offsets']:.2f}",
-    f"Net out-of-pocket: {cp['net_out_of_pocket']:.2f}",
-]
-if cp.get("runway_months") is not None:
-    pdf_lines.append(f"Runway: {cp['runway_months']:.1f} months")
-pdf_lines.append("Decision log:")
-for entry in cp["decision_log"]:
-    pdf_lines.append(f" - {entry}")
-pdf_lines.append("Expert flags:")
-for flag in cp["expert_flags"]:
-    pdf_lines.append(f" - {flag}")
-pdf_bytes = "\n".join(pdf_lines).encode("utf-8")
+    csv_buffer = io.StringIO()
+    csv_writer = csv.writer(csv_buffer)
+    csv_writer.writerow(["category", "amount"])
+    for row in breakdown_rows:
+        csv_writer.writerow([row["Category"], row["Monthly"]])
+    csv_writer.writerow(["Net out-of-pocket", cp["net_out_of_pocket"]])
 
-col_pdf, col_csv, col_json = st.columns(3)
-col_pdf.download_button("Download PDF", data=pdf_bytes, file_name="cost_planner_summary.pdf", mime="application/pdf")
-col_csv.download_button("Download CSV", data=csv_buffer.getvalue(), file_name="cost_planner_summary.csv", mime="text/csv")
-col_json.download_button("Download JSON", data=json_bytes, file_name="cost_planner_summary.json", mime="application/json")
+    pdf_lines = [
+        "Senior Navigator Cost Planner Summary",
+        f"Monthly costs: {cp['monthly_total']:.2f}",
+        f"Offsets: {cp['subtotals']['offsets']:.2f}",
+        f"Net out-of-pocket: {cp['net_out_of_pocket']:.2f}",
+    ]
+    if cp.get("runway_months") is not None:
+        pdf_lines.append(f"Runway: {cp['runway_months']:.1f} months")
+    pdf_lines.append("Decision log:")
+    for entry in cp["decision_log"]:
+        pdf_lines.append(f" - {entry}")
+    pdf_lines.append("Expert flags:")
+    for flag in cp["expert_flags"]:
+        pdf_lines.append(f" - {flag}")
+    pdf_bytes = "\n".join(pdf_lines).encode("utf-8")
 
-with st.expander("Debug snapshot"):
-    st.json(snapshot)
+    col_pdf, col_csv, col_json = st.columns(3)
+    col_pdf.download_button(
+        "Download PDF",
+        data=pdf_bytes,
+        file_name="cost_planner_summary.pdf",
+        mime="application/pdf",
+    )
+    col_csv.download_button(
+        "Download CSV",
+        data=csv_buffer.getvalue(),
+        file_name="cost_planner_summary.csv",
+        mime="text/csv",
+    )
+    col_json.download_button(
+        "Download JSON",
+        data=json_bytes,
+        file_name="cost_planner_summary.json",
+        mime="application/json",
+    )
 
-st.markdown("---")
+    with st.expander("Debug snapshot"):
+        st.json(snapshot)
 
-col_hub, col_back, col_next = st.columns([1, 1, 1])
-with col_hub:
-    if st.button("Return to Hub", type="secondary"):
+    clicked = render_nav_buttons(
+        [
+            NavButton("Return to Hub", "summary_back_hub"),
+            NavButton("Back: Expert Review", "summary_back_review"),
+            NavButton("Next: Confirm & Share", "summary_next_confirm", type="primary"),
+        ]
+    )
+
+    if clicked == "summary_back_hub":
         st.switch_page("pages/hub.py")
-with col_back:
-    if st.button("Back: Expert Review"):
+    elif clicked == "summary_back_review":
         st.switch_page("pages/cost_planner_evaluation.py")
-with col_next:
-    if st.button("Next: Confirm & Share", type="primary"):
+    elif clicked == "summary_next_confirm":
         st.switch_page("pages/cost_plan_confirm.py")
-
-st.markdown('</div>', unsafe_allow_html=True)

--- a/pages/cost_planner_evaluation.py
+++ b/pages/cost_planner_evaluation.py
@@ -1,21 +1,30 @@
 """Expert review drawer for Cost Planner."""
 from __future__ import annotations
-from ui.theme import inject_theme
 
 import streamlit as st
 
 from cost_planner_shared import (
-
     ensure_core_state,
     expert_flag,
     format_currency,
     get_numeric,
     recompute_costs,
-
-
 )
-inject_theme()
-st.markdown('<div class="sn-scope dashboard">', unsafe_allow_html=True)
+from ui.cost_planner_template import (
+    Metric,
+    NavButton,
+    apply_cost_planner_theme,
+    cost_planner_page_container,
+    render_app_header,
+    render_metrics,
+    render_nav_buttons,
+    render_suggestion,
+    render_wizard_help,
+    render_wizard_hero,
+)
+
+
+apply_cost_planner_theme()
 
 
 ensure_core_state()
@@ -40,39 +49,47 @@ if gcp.get("care_intensity") == "high" and get_numeric("care_base_rate") == 0:
 if cp["mode"] == "planning" and cp.get("runway_months") is None:
     expert_flag("Planning mode without positive runway")
 
-st.title("Expert review & decision trace")
-st.caption("Resolve any flagged inconsistencies before generating exports.")
 
-if cp["expert_flags"]:
-    for flag in cp["expert_flags"]:
-        st.warning(flag, icon="⚠️")
-else:
-    st.success("No expert review flags at this time.", icon="✅")
+with cost_planner_page_container():
+    render_app_header()
+    render_wizard_hero(
+        "Expert review & decision trace",
+        "Resolve any flagged inconsistencies before generating exports.",
+    )
 
-st.subheader("Decision log")
-if cp["decision_log"]:
-    for entry in cp["decision_log"]:
-        st.write(f"* {entry}")
-else:
-    st.caption("No decisions logged yet.")
+    if cp["expert_flags"]:
+        for flag in cp["expert_flags"]:
+            render_suggestion(flag, tone="warn")
+    else:
+        render_suggestion("No expert review flags at this time.", tone="info")
 
-st.subheader("Snapshot checks")
-st.metric("Monthly costs", format_currency(cp["monthly_total"]))
-st.metric("Net out-of-pocket", format_currency(cp["net_out_of_pocket"]))
-if cp.get("runway_months") is not None:
-    st.metric("Runway (months)", f"{cp['runway_months']:.1f}")
+    st.subheader("Decision log")
+    if cp["decision_log"]:
+        for entry in cp["decision_log"]:
+            st.write(f"* {entry}")
+    else:
+        render_wizard_help("No decisions logged yet. Notes will appear here as planners make updates.")
 
-st.markdown("---")
+    st.subheader("Snapshot checks")
+    metrics = [
+        Metric("Monthly costs", format_currency(cp["monthly_total"])),
+        Metric("Net out-of-pocket", format_currency(cp["net_out_of_pocket"])),
+    ]
+    if cp.get("runway_months") is not None:
+        metrics.append(Metric("Runway (months)", f"{cp['runway_months']:.1f}"))
+    render_metrics(metrics)
 
-col_hub, col_back, col_next = st.columns([1, 1, 1])
-with col_hub:
-    if st.button("Return to Hub", type="secondary"):
+    clicked = render_nav_buttons(
+        [
+            NavButton("Return to Hub", "evaluation_back_hub"),
+            NavButton("Back: Debts & Other", "evaluation_back_debts"),
+            NavButton("Next: Summary", "evaluation_next_summary", type="primary"),
+        ]
+    )
+
+    if clicked == "evaluation_back_hub":
         st.switch_page("pages/hub.py")
-with col_back:
-    if st.button("Back: Debts & Other"):
+    elif clicked == "evaluation_back_debts":
         st.switch_page("pages/cost_planner_freeform.py")
-with col_next:
-    if st.button("Next: Summary", type="primary"):
+    elif clicked == "evaluation_next_summary":
         st.switch_page("pages/cost_planner_estimate_summary.py")
-
-st.markdown('</div>', unsafe_allow_html=True)

--- a/pages/cost_planner_freeform.py
+++ b/pages/cost_planner_freeform.py
@@ -1,103 +1,124 @@
 """Debts, other expenses, and custom line items."""
 from __future__ import annotations
-from ui.theme import inject_theme
 
 import streamlit as st
 
 from cost_planner_shared import add_decision_log, ensure_core_state, format_currency, get_numeric, recompute_costs, set_numeric
+from ui.cost_planner_template import (
+    Metric,
+    NavButton,
+    apply_cost_planner_theme,
+    cost_planner_page_container,
+    render_app_header,
+    render_metrics,
+    render_nav_buttons,
+    render_wizard_help,
+    render_wizard_hero,
+)
 
 
-inject_theme()
-st.markdown('<div class="sn-scope dashboard">', unsafe_allow_html=True)
+apply_cost_planner_theme()
 
 
 ensure_core_state()
 cp = st.session_state["cost_planner"]
 
-st.title("Debts, other expenses, and custom items")
-st.caption("Capture debts, miscellaneous spending, and tailor additional line items.")
 
-col_debt1, col_debt2 = st.columns(2)
-with col_debt1:
-    cc = st.number_input(
-        "Credit card payments",
+with cost_planner_page_container():
+    render_app_header()
+    render_wizard_hero(
+        "Debts, other expenses, and custom items",
+        "Capture debts, miscellaneous spending, and tailor additional line items.",
+    )
+
+    col_debt1, col_debt2 = st.columns(2)
+    with col_debt1:
+        cc = st.number_input(
+            "Credit card payments",
+            min_value=0.0,
+            step=25.0,
+            value=float(get_numeric("debt_credit_cards")),
+        )
+        set_numeric("debt_credit_cards", cc)
+    with col_debt2:
+        loans = st.number_input(
+            "Loan payments",
+            min_value=0.0,
+            step=25.0,
+            value=float(get_numeric("debt_loans")),
+        )
+        set_numeric("debt_loans", loans)
+
+    cp.setdefault("custom_line_items", [])
+    cp.setdefault("other_base", float(get_numeric("other_miscellaneous")))
+
+    base_other = st.number_input(
+        "Other monthly expenses",
         min_value=0.0,
         step=25.0,
-        value=float(get_numeric("debt_credit_cards")),
+        value=float(cp.get("other_base", 0.0)),
+        help="Transportation, clubs, subscriptions, or other planned amounts.",
     )
-    set_numeric("debt_credit_cards", cc)
-with col_debt2:
-    loans = st.number_input(
-        "Loan payments",
-        min_value=0.0,
-        step=25.0,
-        value=float(get_numeric("debt_loans")),
+    if base_other != cp.get("other_base"):
+        cp["other_base"] = base_other
+
+    with st.form("custom_line_item_form", clear_on_submit=True):
+        st.subheader("Add custom line item")
+        label = st.text_input("Description", placeholder="Companion membership, private chef, etc.")
+        amount = st.number_input("Monthly amount", min_value=0.0, step=25.0)
+        submit = st.form_submit_button("Add line item")
+        if submit and label.strip() and amount > 0:
+            cp["custom_line_items"].append({"label": label.strip(), "amount": float(amount)})
+            add_decision_log(f"Custom item added: {label.strip()}")
+
+    if cp["custom_line_items"]:
+        st.subheader("Custom items")
+        removal_keys = []
+        for idx, item in enumerate(cp["custom_line_items"]):
+            cols = st.columns([3, 1])
+            cols[0].write(f"**{item['label']}** - {format_currency(item['amount'])}")
+            if cols[1].button("Remove", key=f"remove_custom_{idx}"):
+                removal_keys.append(idx)
+        if removal_keys:
+            for index in sorted(removal_keys, reverse=True):
+                del cp["custom_line_items"][index]
+
+    cp.setdefault("notes", "")
+    notes = st.text_area(
+        "Planner notes",
+        value=cp.get("notes", ""),
+        help="Context for advisors reviewing this estimate.",
     )
-    set_numeric("debt_loans", loans)
+    cp["notes"] = notes
 
-cp.setdefault("custom_line_items", [])
-cp.setdefault("other_base", float(get_numeric("other_miscellaneous")))
+    # Sync "other" subtotal with base + custom
+    custom_total = sum(item["amount"] for item in cp["custom_line_items"])
+    set_numeric("other_miscellaneous", cp.get("other_base", 0.0) + custom_total)
 
-base_other = st.number_input(
-    "Other monthly expenses",
-    min_value=0.0,
-    step=25.0,
-    value=float(cp.get("other_base", 0.0)),
-    help="Transportation, clubs, subscriptions, or other planned amounts.",
-)
-if base_other != cp.get("other_base"):
-    cp["other_base"] = base_other
+    recompute_costs()
 
-with st.form("custom_line_item_form", clear_on_submit=True):
-    st.subheader("Add custom line item")
-    label = st.text_input("Description", placeholder="Companion membership, private chef, etc.")
-    amount = st.number_input("Monthly amount", min_value=0.0, step=25.0)
-    submit = st.form_submit_button("Add line item")
-    if submit and label.strip() and amount > 0:
-        cp["custom_line_items"].append({"label": label.strip(), "amount": float(amount)})
-        add_decision_log(f"Custom item added: {label.strip()}")
+    other_subtotal = format_currency(cp["subtotals"]["other"])
+    render_metrics(
+        [
+            Metric(
+                "Other & debts subtotal",
+                format_currency(cp["subtotals"]["other"] + cp["subtotals"]["debts"]),
+            )
+        ]
+    )
+    render_wizard_help(f"Other expenses currently total {other_subtotal} before debt payments.")
 
-if cp["custom_line_items"]:
-    st.subheader("Custom items")
-    removal_keys = []
-    for idx, item in enumerate(cp["custom_line_items"]):
-        cols = st.columns([3, 1])
-        cols[0].write(f"**{item['label']}** - {format_currency(item['amount'])}")
-        if cols[1].button("Remove", key=f"remove_custom_{idx}"):
-            removal_keys.append(idx)
-    if removal_keys:
-        for index in sorted(removal_keys, reverse=True):
-            del cp["custom_line_items"][index]
+    clicked = render_nav_buttons(
+        [
+            NavButton("Return to Hub", "freeform_back_hub"),
+            NavButton("Back: Benefits", "freeform_back_benefits"),
+            NavButton("Next: Expert Review", "freeform_next_review", type="primary"),
+        ]
+    )
 
-cp.setdefault("notes", "")
-notes = st.text_area(
-    "Planner notes",
-    value=cp.get("notes", ""),
-    help="Context for advisors reviewing this estimate.",
-)
-cp["notes"] = notes
-
-# Sync "other" subtotal with base + custom
-custom_total = sum(item["amount"] for item in cp["custom_line_items"])
-set_numeric("other_miscellaneous", cp.get("other_base", 0.0) + custom_total)
-
-recompute_costs()
-
-other_subtotal = format_currency(cp["subtotals"]["other"])
-st.metric("Other & debts subtotal", format_currency(cp["subtotals"]["other"] + cp["subtotals"]["debts"]))
-st.caption(f"Other expenses: {other_subtotal}")
-
-st.markdown("---")
-
-col_hub, col_back, col_next = st.columns([1, 1, 1])
-with col_hub:
-    if st.button("Return to Hub", type="secondary"):
+    if clicked == "freeform_back_hub":
         st.switch_page("pages/hub.py")
-with col_back:
-    if st.button("Back: Benefits"):
+    elif clicked == "freeform_back_benefits":
         st.switch_page("pages/cost_planner_benefits.py")
-with col_next:
-    if st.button("Next: Expert Review", type="primary"):
+    elif clicked == "freeform_next_review":
         st.switch_page("pages/cost_planner_evaluation.py")
-
-st.markdown('</div>', unsafe_allow_html=True)

--- a/pages/cost_planner_housing.py
+++ b/pages/cost_planner_housing.py
@@ -1,14 +1,24 @@
 """Housing drawer for the Cost Planner."""
 from __future__ import annotations
-from ui.theme import inject_theme
 
 import streamlit as st
 
 from cost_planner_shared import ensure_core_state, format_currency, get_numeric, recompute_costs, set_numeric
+from ui.cost_planner_template import (
+    Metric,
+    NavButton,
+    apply_cost_planner_theme,
+    cost_planner_page_container,
+    render_app_header,
+    render_metrics,
+    render_nav_buttons,
+    render_suggestion,
+    render_wizard_help,
+    render_wizard_hero,
+)
 
 
-inject_theme()
-st.markdown('<div class="sn-scope dashboard">', unsafe_allow_html=True)
+apply_cost_planner_theme()
 
 
 ensure_core_state()
@@ -16,63 +26,74 @@ cp = st.session_state["cost_planner"]
 aud = st.session_state["audiencing"]
 quals = aud.get("qualifiers", {})
 
-st.title("Housing and living costs")
-st.caption("Capture recurring housing payments before care or benefits.")
 
-if not quals.get("owns_home"):
-    st.info(
-        "Audiencing shows this household does not own a home. Home maintenance fields are hidden and treated as $0.",
-        icon="🏢",
+with cost_planner_page_container():
+    render_app_header()
+    render_wizard_hero(
+        "Housing and living costs",
+        "Capture recurring housing payments before care or benefits.",
     )
 
-base_rent = st.number_input(
-    "Monthly housing cost (rent, mortgage, or community fee)",
-    min_value=0.0,
-    step=50.0,
-    value=float(get_numeric("housing_base_rent")),
-    help="Include rent, mortgage, or assisted living base fees.",
-)
-set_numeric("housing_base_rent", base_rent)
+    if not quals.get("owns_home"):
+        render_suggestion(
+            "Audiencing shows this household does not own a home. Home maintenance fields are hidden and treated as $0.",
+            tone="info",
+        )
 
-col_a, col_b = st.columns(2)
-with col_a:
-    utilities = st.number_input(
-        "Utilities & services",
+    base_rent = st.number_input(
+        "Monthly housing cost (rent, mortgage, or community fee)",
         min_value=0.0,
-        step=25.0,
-        value=float(get_numeric("housing_utilities")),
-        help="Electric, water, trash, cable, HOA dues.",
+        step=50.0,
+        value=float(get_numeric("housing_base_rent")),
+        help="Include rent, mortgage, or assisted living base fees.",
     )
-    set_numeric("housing_utilities", utilities)
+    set_numeric("housing_base_rent", base_rent)
 
-with col_b:
-    if quals.get("owns_home"):
-        maintenance = st.number_input(
-            "Maintenance or HOA",
+    col_a, col_b = st.columns(2)
+    with col_a:
+        utilities = st.number_input(
+            "Utilities & services",
             min_value=0.0,
             step=25.0,
-            value=float(get_numeric("housing_maintenance")),
-            help="Repairs, lawn care, or HOA assessments.",
+            value=float(get_numeric("housing_utilities")),
+            help="Electric, water, trash, cable, HOA dues.",
         )
-        set_numeric("housing_maintenance", maintenance)
-    else:
-        set_numeric("housing_maintenance", 0.0)
+        set_numeric("housing_utilities", utilities)
 
-recompute_costs()
+    with col_b:
+        if quals.get("owns_home"):
+            maintenance = st.number_input(
+                "Maintenance or HOA",
+                min_value=0.0,
+                step=25.0,
+                value=float(get_numeric("housing_maintenance")),
+                help="Repairs, lawn care, or HOA assessments.",
+            )
+            set_numeric("housing_maintenance", maintenance)
+        else:
+            set_numeric("housing_maintenance", 0.0)
 
-st.metric("Housing subtotal", format_currency(cp["subtotals"]["housing"]))
+    recompute_costs()
 
-st.markdown("---")
+    render_metrics(
+        [
+            Metric("Housing subtotal", format_currency(cp["subtotals"]["housing"]))
+        ]
+    )
 
-col_hub, col_back, col_next = st.columns([1, 1, 1])
-with col_hub:
-    if st.button("Return to Hub", type="secondary"):
+    render_wizard_help("Include rent, mortgage, or assisted living base fees when estimating housing.")
+
+    clicked = render_nav_buttons(
+        [
+            NavButton("Return to Hub", "housing_back_hub"),
+            NavButton("Back to Intro", "housing_back_intro"),
+            NavButton("Next: Care", "housing_next_care", type="primary"),
+        ]
+    )
+
+    if clicked == "housing_back_hub":
         st.switch_page("pages/hub.py")
-with col_back:
-    if st.button("Back to Intro"):
+    elif clicked == "housing_back_intro":
         st.switch_page("pages/cost_planner_estimate.py")
-with col_next:
-    if st.button("Next: Care", type="primary"):
+    elif clicked == "housing_next_care":
         st.switch_page("pages/cost_planner_home_care.py")
-
-st.markdown('</div>', unsafe_allow_html=True)

--- a/pages/cost_planner_mods.py
+++ b/pages/cost_planner_mods.py
@@ -1,61 +1,78 @@
 
+from __future__ import annotations
+
 import streamlit as st
-from ui.theme import inject_theme
+
+from ui.cost_planner_template import (
+    NavButton,
+    apply_cost_planner_theme,
+    cost_planner_page_container,
+    render_app_header,
+    render_nav_buttons,
+    render_wizard_help,
+    render_wizard_hero,
+)
 
 
-inject_theme()
-st.markdown('<div class="sn-scope dashboard">', unsafe_allow_html=True)
+apply_cost_planner_theme()
 
 
-# Debug: non-visual logger
-def _debug_log(msg: str):
+def _debug_log(msg: str) -> None:
     try:
         print(f"[SNAV] {msg}")
     except Exception:
         pass
 
-_debug_log('LOADED: cost_planner_mods.py')
+
+_debug_log("LOADED: cost_planner_mods.py")
 
 
-# Guard: ensure session state keys exist across cold restarts
-if 'care_context' not in st.session_state:
+if "care_context" not in st.session_state:
     st.session_state.care_context = {
-        'gcp_answers': {},
-        'decision_trace': [],
-        'planning_mode': 'exploring',
-        'care_flags': {}
+        "gcp_answers": {},
+        "decision_trace": [],
+        "planning_mode": "exploring",
+        "care_flags": {},
     }
-ctx = st.session_state.care_context
 
 
-# Cost Planner: Age-in-Place Upgrades
-st.markdown('<div class="scn-hero">', unsafe_allow_html=True)
-st.title("Age-in-Place Upgrades for your loved one")
-st.markdown("<h2>Make his home safer.</h2>", unsafe_allow_html=True)
-st.markdown("<p>Add upgrades to support independence.</p>", unsafe_allow_html=True)
-st.markdown('</div>', unsafe_allow_html=True)
+with cost_planner_page_container():
+    render_app_header()
+    render_wizard_hero(
+        "Age-in-place upgrades",
+        "Capture accessibility improvements that keep the home safe and comfortable.",
+    )
 
-# Upgrades options with tile style
-st.markdown('<div style="border: 1px solid #e0e0e0; border-radius: 8px; padding: 1.5rem; text-align: left; min-height: 250px;">', unsafe_allow_html=True)
-st.markdown("### Upgrade Options")
-st.markdown("<p>Select upgrades for your loved one's home.</p>", unsafe_allow_html=True)
-st.write("Grab bars?")
-st.button("Yes", key="cm_grab_yes", type="primary")
-st.button("No", key="cm_grab_no", type="primary")
+    st.subheader("Upgrade options")
+    grab_bars = st.checkbox("Grab bars and bathroom supports")
+    stair_lift = st.checkbox("Stair lift or ramp installation")
+    lighting = st.checkbox("Smart lighting and fall prevention sensors")
 
-st.write("Stair lift?")
-st.button("Yes", key="cm_stair_yes", type="primary")
-st.button("No", key="cm_stair_no", type="primary")
+    selected = [
+        label
+        for label, checked in [
+            ("Grab bars", grab_bars),
+            ("Stair lift", stair_lift),
+            ("Smart lighting", lighting),
+        ]
+        if checked
+    ]
 
-st.markdown('</div>', unsafe_allow_html=True)
+    if selected:
+        render_wizard_help(
+            "We'll translate selected upgrades into estimated project budgets during implementation.",
+        )
+    else:
+        render_wizard_help("Not ready to choose upgrades? You can revisit this later.")
 
-# Navigation
-st.markdown('<div class="scn-nav-row">', unsafe_allow_html=True)
-col1, col2 = st.columns([1, 1])
-with col1:
-    st.button("Back to Modules", key="back_cm", type="secondary")
-with col2:
-    st.button("Next Option", key="next_cm", type="primary")
-st.markdown('</div>', unsafe_allow_html=True)
+    clicked = render_nav_buttons(
+        [
+            NavButton("Back to Modules", "mods_back_modules"),
+            NavButton("Next Option", "mods_next_option", type="primary"),
+        ]
+    )
 
-st.markdown('</div>', unsafe_allow_html=True)
+    if clicked == "mods_back_modules":
+        st.switch_page("pages/cost_planner_modules.py")
+    elif clicked == "mods_next_option":
+        st.switch_page("pages/cost_planner_skipped.py")

--- a/pages/cost_planner_modules.py
+++ b/pages/cost_planner_modules.py
@@ -1,76 +1,117 @@
 import streamlit as st
-from ui.theme import inject_theme
+
+from ui.cost_planner_template import (
+    NavButton,
+    apply_cost_planner_theme,
+    cost_planner_page_container,
+    render_app_header,
+    render_module_cards,
+    render_nav_buttons,
+    render_wizard_help,
+    render_wizard_hero,
+)
 
 
-inject_theme()
-st.markdown('<div class="sn-scope dashboard">', unsafe_allow_html=True)
+apply_cost_planner_theme()
 
 
-# Guard
-if 'care_context' not in st.session_state:
+if "care_context" not in st.session_state:
     st.session_state.care_context = {}
 
 ctx = st.session_state.care_context
-person_name = ctx.get('person_name', 'Your Loved One')
-estimate = ctx.get('cost_estimate', {})
-est_completed = bool(estimate.get('completed'))
-est_setting = estimate.get('setting_label') or estimate.get('setting') or ''
-est_zip = estimate.get('zip', '')
-est_monthly = estimate.get('estimate_monthly')
+person_name = ctx.get("person_name", "Your Loved One")
+estimate = ctx.get("cost_estimate", {})
+est_completed = bool(estimate.get("completed"))
+est_setting = estimate.get("setting_label") or estimate.get("setting") or ""
+est_zip = estimate.get("zip", "")
+est_monthly = estimate.get("estimate_monthly")
 
-st.title(f"Recommended Cost Modules for {person_name}")
-st.caption("Work through the modules below. You can return to any module at any time.")
-st.markdown('---')
 
-# Quick Estimate tile
-with st.container(border=True):
-    cols = st.columns([4, 2, 2])
-    with cols[0]:
-        st.subheader("Cost of Care Planner")
-        if est_completed and est_monthly:
-            summary = f"{est_setting or 'In-home care'} * ${est_monthly:,}/mo"
-            if est_zip:
-                summary += f" * ZIP {est_zip}"
-            st.caption(summary)
-        else:
-            st.caption("Get a quick monthly estimate based on setting, ZIP, and a few simple details.")
-    with cols[1]:
-        if st.button("Open", key="open_quick_estimate"):
-            st.switch_page("pages/cost_planner_estimate.py")
-    with cols[2]:
-        if est_completed:
-            st.success("Completed", icon="✅")
-        else:
-            st.info("Not started", icon="ℹ️")  # fixed icon
+with cost_planner_page_container():
+    render_app_header()
+    render_wizard_hero(
+        f"Recommended Cost Modules for {person_name}",
+        "Work through the modules below. You can return to any module at any time.",
+    )
 
-st.markdown('---')
+    summary = "Get a quick monthly estimate based on setting, ZIP, and a few simple details."
+    if est_completed and est_monthly:
+        summary = f"{est_setting or 'In-home care'} • ${est_monthly:,}/mo"
+        if est_zip:
+            summary += f" • ZIP {est_zip}"
 
-# Other module tiles (simple stubs)
-def module_tile(title, caption, key, page):
-    with st.container(border=True):
-        cols = st.columns([4,2,2])
-        with cols[0]:
-            st.subheader(title)
-            st.caption(caption)
-        with cols[1]:
-            if st.button("Open", key=key):
-                st.switch_page(page)
-        with cols[2]:
-            st.caption(" ")
+    cards = [
+        {
+            "title": "Cost of Care Planner",
+            "description": summary,
+            "status": "Completed" if est_completed else "Not started",
+            "status_class": "positive" if est_completed else "",
+            "actions": [
+                {"label": "Open", "key": "open_quick_estimate", "type": "primary"},
+            ],
+        },
+        {
+            "title": "Home Care Support",
+            "description": "Hourly in-home caregiving and companion support.",
+            "actions": [
+                {"label": "Open", "key": "open_home_care", "type": "secondary"},
+            ],
+        },
+        {
+            "title": "Daily Living Aids",
+            "description": "Equipment and supplies that support daily safety and independence.",
+            "actions": [
+                {"label": "Open", "key": "open_daily_aids", "type": "secondary"},
+            ],
+        },
+        {
+            "title": "Housing Path",
+            "description": "Assisted living, memory care, or other residential options.",
+            "actions": [
+                {"label": "Open", "key": "open_housing", "type": "secondary"},
+            ],
+        },
+        {
+            "title": "Benefits Check",
+            "description": "VA, Medicaid, LTC insurance, and other offsets.",
+            "actions": [
+                {"label": "Open", "key": "open_benefits", "type": "secondary"},
+            ],
+        },
+        {
+            "title": "Age-in-Place Upgrades",
+            "description": "Home safety modifications and accessibility improvements.",
+            "actions": [
+                {"label": "Open", "key": "open_mods", "type": "secondary"},
+            ],
+        },
+    ]
 
-module_tile("Home Care Support", "Hourly in-home caregiving and companion support.", "open_home_care", "pages/cost_planner_home_care.py")
-module_tile("Daily Living Aids", "Equipment and supplies that support daily safety and independence.", "open_daily_aids", "pages/cost_planner_daily_aids.py")
-module_tile("Housing Path", "Assisted living, memory care, or other residential options.", "open_housing", "pages/cost_planner_housing.py")
-module_tile("Benefits Check", "VA, Medicaid, LTC insurance, and other offsets.", "open_benefits", "pages/cost_planner_benefits.py")
-module_tile("Age-in-Place Upgrades", "Home safety modifications and accessibility improvements.", "open_mods", "pages/cost_planner_mods.py")
+    triggered = render_module_cards(cards)
 
-st.markdown('---')
-c1, c2 = st.columns(2)
-with c1:
-    if st.button("Back to Mode", key="mods_back_mode"):
+    if triggered == "open_quick_estimate":
+        st.switch_page("pages/cost_planner_estimate.py")
+    elif triggered == "open_home_care":
+        st.switch_page("pages/cost_planner_home_care.py")
+    elif triggered == "open_daily_aids":
+        st.switch_page("pages/cost_planner_daily_aids.py")
+    elif triggered == "open_housing":
+        st.switch_page("pages/cost_planner_housing.py")
+    elif triggered == "open_benefits":
+        st.switch_page("pages/cost_planner_benefits.py")
+    elif triggered == "open_mods":
+        st.switch_page("pages/cost_planner_mods.py")
+
+    render_wizard_help("You can revisit modules any time—progress saves automatically.")
+
+    clicked = render_nav_buttons(
+        [
+            NavButton("Back to Mode", "mods_back_mode"),
+            NavButton("Expert Review", "mods_expert_review", type="primary"),
+        ]
+    )
+
+    if clicked == "mods_back_mode":
         st.switch_page("pages/cost_planner.py")
-with c2:
-    if st.button("Expert Review", key="mods_expert_review"):
+    elif clicked == "mods_expert_review":
         st.switch_page("pages/expert_review.py")
-
-st.markdown('</div>', unsafe_allow_html=True)

--- a/pages/cost_planner_skipped.py
+++ b/pages/cost_planner_skipped.py
@@ -1,52 +1,63 @@
 
+from __future__ import annotations
+
 import streamlit as st
-from ui.theme import inject_theme
+
+from ui.cost_planner_template import (
+    NavButton,
+    apply_cost_planner_theme,
+    cost_planner_page_container,
+    render_app_header,
+    render_nav_buttons,
+    render_wizard_help,
+    render_wizard_hero,
+)
 
 
-inject_theme()
-st.markdown('<div class="sn-scope dashboard">', unsafe_allow_html=True)
+apply_cost_planner_theme()
 
 
-# Debug: non-visual logger
-def _debug_log(msg: str):
+def _debug_log(msg: str) -> None:
     try:
         print(f"[SNAV] {msg}")
     except Exception:
         pass
 
-_debug_log('LOADED: cost_planner_skipped.py')
+
+_debug_log("LOADED: cost_planner_skipped.py")
 
 
-# Guard: ensure session state keys exist across cold restarts
-if 'care_context' not in st.session_state:
+if "care_context" not in st.session_state:
     st.session_state.care_context = {
-        'gcp_answers': {},
-        'decision_trace': [],
-        'planning_mode': 'exploring',
-        'care_flags': {}
+        "gcp_answers": {},
+        "decision_trace": [],
+        "planning_mode": "exploring",
+        "care_flags": {},
     }
-ctx = st.session_state.care_context
 
 
-# Cost Planner: Skipped
-st.markdown('<div class="scn-hero">', unsafe_allow_html=True)
-st.title("Skipped Modules for your loved one")
-st.markdown("<h2>Review what you missed.</h2>", unsafe_allow_html=True)
-st.markdown("<p>Add these later if needed.</p>", unsafe_allow_html=True)
-st.markdown('</div>', unsafe_allow_html=True)
+with cost_planner_page_container():
+    render_app_header()
+    render_wizard_hero(
+        "Skipped modules",
+        "Review what you skipped and reopen them when you're ready.",
+    )
 
-# Skipped modules tile
-st.markdown('<div style="border: 1px solid #e0e0e0; border-radius: 8px; padding: 1.5rem; text-align: left; min-height: 250px;">', unsafe_allow_html=True)
-st.markdown("### Skipped Items")
-st.markdown("<p>You skipped: Housing Path, Benefits Check.</p>", unsafe_allow_html=True)
-st.button("Revisit Skipped", key="revisit_skipped", type="primary")
-st.markdown('</div>', unsafe_allow_html=True)
+    skipped_modules = ["Housing Path", "Benefits Check"]
+    st.subheader("Skipped items")
+    for module in skipped_modules:
+        st.write(f"• {module}")
 
-# Navigation
-st.markdown('<div class="scn-nav-row">', unsafe_allow_html=True)
-col1, col2 = st.columns([1, 1])
-with col1:
-    st.button("Back to Evaluation", key="back_skipped", type="secondary")
-st.markdown('</div>', unsafe_allow_html=True)
+    render_wizard_help("You can revisit these modules any time from the Cost Planner dashboard.")
 
-st.markdown('</div>', unsafe_allow_html=True)
+    clicked = render_nav_buttons(
+        [
+            NavButton("Back to Evaluation", "skipped_back_evaluation"),
+            NavButton("Revisit Modules", "skipped_revisit", type="primary"),
+        ]
+    )
+
+    if clicked == "skipped_back_evaluation":
+        st.switch_page("pages/cost_planner_evaluation.py")
+    elif clicked == "skipped_revisit":
+        st.switch_page("pages/cost_planner_modules.py")

--- a/ui/cost_planner_template.py
+++ b/ui/cost_planner_template.py
@@ -1,0 +1,226 @@
+"""Shared helpers for Cost Planner wireframe styling.
+
+These utilities provide the TurboTax-inspired presentation that the
+product team wants to see applied consistently across every
+``cost_planner*`` Streamlit page.  They intentionally focus on layout
+and tone; business logic should stay within the individual pages.
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+import streamlit as st
+
+from ui.theme import inject_theme
+
+
+@dataclass
+class Metric:
+    label: str
+    value: str
+    delta: Optional[str] = None
+
+
+@dataclass
+class NavButton:
+    label: str
+    key: str
+    type: str = "secondary"
+
+
+def apply_cost_planner_theme() -> None:
+    """Inject the shared theme and CSS used by the wireframes."""
+
+    inject_theme()
+
+    st.markdown(
+        """
+<style>
+/* Header and Navigation */
+.stAppHeader { background-color: #f0f8ff; padding: 1rem; border-bottom: 1px solid #d3d3d3; }
+.stAppHeader h1 { color: #1e90ff; font-size: 24px; margin: 0; }
+.nav-bar { display: flex; justify-content: space-between; align-items: center; gap: 1rem; }
+.nav-item { color: #4682b4; margin-right: 1rem; text-decoration: none; font-weight: 500; }
+.login-btn { background-color: #1e90ff; color: white; padding: 0.5rem 1rem; border-radius: 20px; border: none; font-weight: 600; }
+
+/* Qualifiers Header */
+.qual-header { display: flex; align-items: center; padding: 1rem; border-bottom: 1px solid #d3d3d3; gap: 0.75rem; }
+.back-btn { color: #1e90ff; font-size: 18px; cursor: pointer; }
+.assess-label { color: #808080; font-size: 14px; }
+.name-btn { background-color: #f0f8ff; color: #1e90ff; border-radius: 20px; padding: 0.2rem 0.8rem; border: 0; font-weight: 600; }
+.question-mode { color: #1e90ff; font-size: 14px; margin-left: auto; }
+
+/* Wizard Styling */
+.wizard-hero { background: #f0f8ff; padding: 2rem; text-align: center; border-radius: 20px; margin-bottom: 2rem; }
+.wizard-title { font-size: 32px; color: #1e90ff; margin-bottom: 0.5rem; }
+.wizard-caption { font-size: 17px; color: #808080; max-width: 720px; margin: 0 auto; }
+.wizard-help { background-color: #f0f8ff; color: #606060; padding: 0.75rem 1rem; border-radius: 12px; margin-top: 1.25rem; border: 1px solid #d3d3d3; }
+.wizard-button { padding: 0.5rem 1.25rem; border-radius: 20px; font-weight: 600; display: inline-flex; align-items: center; justify-content: center; border: none; cursor: pointer; }
+.wizard-button-primary { background-color: #1e90ff; color: white; }
+.wizard-button-secondary { background-color: #f0f8ff; color: #1e90ff; border: 1px solid #d3d3d3; }
+.wizard-suggestion { padding: 1rem; border-radius: 12px; margin-bottom: 1rem; font-size: 15px; }
+.wizard-suggestion-info { background-color: #e6f0fa; color: #1e90ff; }
+.wizard-suggestion-warn { background-color: #fff3cd; color: #856404; }
+.wizard-suggestion-critical { background-color: #f8d7da; color: #721c24; }
+
+/* Module dashboard cards */
+.module-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; margin: 1.5rem 0; }
+.module-card { background: #ffffff; border-radius: 18px; padding: 1.25rem; border: 1px solid #d3d3d3; box-shadow: 0 12px 30px rgba(30, 144, 255, 0.08); display: flex; flex-direction: column; gap: 0.5rem; }
+.module-card h4 { margin: 0; font-size: 18px; color: #1e90ff; }
+.module-card p { margin: 0; color: #606060; font-size: 14px; }
+.module-card .card-status { display: inline-flex; align-items: center; gap: 0.35rem; background: #f0f8ff; color: #1e90ff; padding: 0.15rem 0.75rem; border-radius: 999px; font-size: 13px; font-weight: 600; }
+.module-card .card-status.positive { background: #e6f7eb; color: #2e8b57; }
+.module-card .card-status.warning { background: #fff3cd; color: #856404; }
+.module-card .card-actions { margin-top: auto; display: flex; gap: 0.5rem; }
+.module-card .card-actions a { text-decoration: none; }
+.module-card .card-actions .wizard-button { width: 100%; }
+
+/* Tables */
+.summary-table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+.summary-table th { text-align: left; font-size: 14px; color: #606060; border-bottom: 1px solid #d3d3d3; padding-bottom: 0.5rem; }
+.summary-table td { padding: 0.65rem 0; border-bottom: 1px solid #ededed; font-size: 15px; }
+.summary-table td.amount { text-align: right; font-weight: 600; color: #1e90ff; }
+
+/* Utility */
+.sn-scope.dashboard.cost-planner-wireframe { padding-bottom: 2rem; }
+</style>
+""",
+        unsafe_allow_html=True,
+    )
+
+
+def render_app_header() -> None:
+    st.markdown(
+        """
+<div class="stAppHeader">
+  <div class="nav-bar">
+    <h1>Concierge Care Senior Navigator</h1>
+    <div>
+      <a class="nav-item" href="#">Dashboard</a>
+      <a class="nav-item" href="#">Learning Center</a>
+      <a class="nav-item" href="#">Get Connected</a>
+      <button class="login-btn">Log in or sign up</button>
+    </div>
+  </div>
+</div>
+""",
+        unsafe_allow_html=True,
+    )
+
+
+def render_assessment_header(section_label: str, *, persona: str = "John", mode: str = "All questions") -> None:
+    st.markdown(
+        f"""
+<div class="qual-header">
+  <span class="back-btn">← Back</span>
+  <span class="assess-label">{section_label}</span>
+  <button class="name-btn">{persona}</button>
+  <span class="question-mode">{mode}</span>
+</div>
+""",
+        unsafe_allow_html=True,
+    )
+
+
+def render_wizard_hero(title: str, caption: str) -> None:
+    st.markdown("<div class='wizard-hero'>", unsafe_allow_html=True)
+    st.markdown(f"<h1 class='wizard-title'>{title}</h1>", unsafe_allow_html=True)
+    st.markdown(f"<p class='wizard-caption'>{caption}</p>", unsafe_allow_html=True)
+    st.markdown("</div>", unsafe_allow_html=True)
+
+
+def render_wizard_help(text: str) -> None:
+    st.markdown(f"<div class='wizard-help'>{text}</div>", unsafe_allow_html=True)
+
+
+def render_metrics(metrics: Iterable[Metric]) -> None:
+    metric_list = list(metrics)
+    if not metric_list:
+        return
+
+    cols = st.columns(len(metric_list))
+    for col, metric in zip(cols, metric_list):
+        with col:
+            st.metric(metric.label, metric.value, metric.delta)
+
+
+def render_nav_buttons(buttons: Iterable[NavButton]) -> Optional[str]:
+    """Render navigation buttons and return the key that was clicked."""
+
+    button_list = list(buttons)
+    if not button_list:
+        return None
+
+    cols = st.columns(len(button_list))
+    for col, button in zip(cols, button_list):
+        with col:
+            if st.button(
+                button.label,
+                key=button.key,
+                type=button.type,
+            ):
+                return button.key
+    return None
+
+
+def render_suggestion(text: str, *, tone: str = "info") -> None:
+    tone_class = {
+        "info": "wizard-suggestion-info",
+        "warn": "wizard-suggestion-warn",
+        "critical": "wizard-suggestion-critical",
+    }.get(tone, "wizard-suggestion-info")
+    st.markdown(
+        f"<div class='wizard-suggestion {tone_class}'>{text}</div>",
+        unsafe_allow_html=True,
+    )
+
+
+def render_module_cards(cards: List[dict]) -> Optional[str]:
+    """Render module cards and return the key of a triggered action, if any."""
+
+    if not cards:
+        return None
+
+    st.markdown("<div class='module-grid'>", unsafe_allow_html=True)
+    triggered: Optional[str] = None
+    for card in cards:
+        st.markdown("<div class='module-card'>", unsafe_allow_html=True)
+        st.markdown(f"<h4>{card.get('title', '')}</h4>", unsafe_allow_html=True)
+        if card.get("description"):
+            st.markdown(f"<p>{card['description']}</p>", unsafe_allow_html=True)
+        if card.get("status"):
+            status_class = card.get("status_class", "")
+            st.markdown(
+                f"<span class='card-status {status_class}'>{card['status']}</span>",
+                unsafe_allow_html=True,
+            )
+        actions = card.get("actions", [])
+        if actions:
+            st.markdown("<div class='card-actions'>", unsafe_allow_html=True)
+            for action in actions:
+                action_key = action.get("key", action.get("label", "btn"))
+                if st.button(
+                    action.get("label", ""),
+                    key=action_key,
+                    type=action.get("type", "secondary"),
+                    help=action.get("help"),
+                ):
+                    triggered = action_key
+            st.markdown("</div>", unsafe_allow_html=True)
+        st.markdown("</div>", unsafe_allow_html=True)
+    st.markdown("</div>", unsafe_allow_html=True)
+    return triggered
+
+
+@contextmanager
+def cost_planner_page_container() -> None:
+    st.markdown(
+        "<div class='sn-scope dashboard cost-planner-wireframe'>",
+        unsafe_allow_html=True,
+    )
+    try:
+        yield
+    finally:
+        st.markdown("</div>", unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- introduce `ui/cost_planner_template` to centralise the TurboTax-style header, hero, metrics, and navigation helpers for Cost Planner pages
- refactor the Cost Planner entry pages to use the shared layout, metrics, and navigation handlers
- update every downstream Cost Planner module, review, summary, and confirmation screen to adopt the new wireframe helpers and consistent navigation

## Testing
- python -m compileall pages ui

------
https://chatgpt.com/codex/tasks/task_b_68e0caa5b174832384d8d4fa2fe088ed