### PR TITLE
Implement cost planner hi-fi shell with Navi mock

### DIFF
--- a/copy/cost_planner_strings.json
+++ b/copy/cost_planner_strings.json
@@ -1,0 +1,226 @@
+{
+  "app": {
+    "title": "Cost Planner",
+    "mode_badges": {
+      "exploring": "Exploring costs",
+      "planning": "Planning with my advisor"
+    },
+    "progress_label": "Step progress",
+    "sidebar": {
+      "totals_title": "Mock monthly outlook",
+      "totals_rows": [
+        [
+          "Housing & Living",
+          "$3,250"
+        ],
+        [
+          "Care Supports",
+          "$2,180"
+        ],
+        [
+          "Medical & Health",
+          "$640"
+        ],
+        [
+          "Insurance & Benefits",
+          "$410"
+        ],
+        [
+          "Debts & Other",
+          "$525"
+        ],
+        [
+          "Estimated Total",
+          "$7,005"
+        ]
+      ],
+      "navi_title": "Need a hand?",
+      "navi_body": "Navi shares quick suggestions as you plan."
+    },
+    "navigation": {
+      "back": "Go back",
+      "continue": "Save & continue",
+      "jump": "Jump to step"
+    },
+    "drawer_summary_label": "Subtotal"
+  },
+  "mode_selection": {
+    "headline": "How would you like to get started?",
+    "cards": {
+      "explore": {
+        "title": "Explore costs",
+        "body": "Walk through an interactive tour with mock costs to see what's possible.",
+        "cta": "Continue exploring"
+      },
+      "plan": {
+        "title": "Plan costs with my advisor",
+        "body": "Sign in so we can save updates and prep a hand-off for your advisor.",
+        "cta": "Sign in to start"
+      }
+    },
+    "login_modal": {
+      "title": "Planning mode uses a secure sign-in",
+      "body": "For now this is a placeholder experience. We'll confirm your account details in a later release.",
+      "confirm": "Looks good"
+    }
+  },
+  "qualifiers": {
+    "title": "Tell us a little about your situation",
+    "description": "These details tailor which costs and tips we highlight.",
+    "contribution_style": {
+      "label": "How will contributors share costs?",
+      "options": {
+        "unified": "We'll pool expenses together",
+        "individual": "We'll split things individually"
+      }
+    },
+    "owns_home": {
+      "label": "Do you own the home where care happens?",
+      "options": {
+        "yes": "Yes, we own it",
+        "no": "No, we rent or live elsewhere"
+      }
+    },
+    "is_veteran": {
+      "label": "Is anyone a veteran or military spouse?",
+      "options": {
+        "yes": "Yes",
+        "no": "No"
+      }
+    },
+    "medicaid_banner": {
+      "title": "Unsure about Medicaid eligibility?",
+      "body": "We can flag local experts who specialize in Medicaid planning so you feel confident in next steps."
+    },
+    "continue": "Save qualifiers"
+  },
+  "drawers": {
+    "housing": {
+      "title": "Housing & daily living",
+      "caption": "Capture the monthly costs that keep your home running smoothly.",
+      "fields": {
+        "rent": "Monthly rent or mortgage",
+        "utilities": "Home utilities and services",
+        "maintenance": "Maintenance & repairs",
+        "home_modifications": "Accessibility upgrades"
+      },
+      "summary_hint": "Includes mortgage, utilities, and upkeep.",
+      "subtotal": "$3,250"
+    },
+    "care": {
+      "title": "Care supports",
+      "caption": "Estimate hands-on care, respite, and community programs.",
+      "fields": {
+        "home_care": "In-home care or companionship",
+        "adult_day": "Adult day or respite programs",
+        "community": "Community or residential care fees"
+      },
+      "summary_hint": "Blends in-home care with occasional respite.",
+      "subtotal": "$2,180"
+    },
+    "medical": {
+      "title": "Medical & wellness",
+      "caption": "Track recurring health costs like prescriptions and appointments.",
+      "fields": {
+        "prescriptions": "Prescription medications",
+        "specialists": "Specialist visits & therapies",
+        "equipment": "Medical equipment & supplies"
+      },
+      "summary_hint": "Includes chronic condition follow-ups.",
+      "subtotal": "$640"
+    },
+    "insurance_benefits": {
+      "title": "Insurance & benefits",
+      "caption": "Stay on top of premiums and benefits that offset costs.",
+      "fields": {
+        "medicare": "Medicare or supplement premiums",
+        "va_benefits": "VA Aid & Attendance or other military benefits",
+        "long_term_care": "Long-term care insurance premiums"
+      },
+      "summary_hint": "Remember to review benefits annually.",
+      "subtotal": "$410"
+    },
+    "debts_other": {
+      "title": "Debts & other priorities",
+      "caption": "Balance transportation, loans, and personal priorities.",
+      "fields": {
+        "transportation": "Transportation & travel",
+        "loans": "Loans or credit balances",
+        "personal": "Personal spending"
+      },
+      "summary_hint": "Highlights flexible spending categories.",
+      "subtotal": "$525"
+    }
+  },
+  "review": {
+    "title": "Review your plan snapshot",
+    "intro": "Use the drawers below to make quick edits before sharing with your advisor.",
+    "accordion": {
+      "housing": "Housing & daily living",
+      "care": "Care supports",
+      "medical": "Medical & wellness",
+      "insurance_benefits": "Insurance & benefits",
+      "debts_other": "Debts & other priorities"
+    },
+    "suggestions_title": "Navi suggests",
+    "suggestions": [
+      {
+        "level": "info",
+        "title": "Review caregiver relief programs",
+        "body": "Check local respite care grants to offset weekly support hours."
+      },
+      {
+        "level": "warning",
+        "title": "Plan a prescription buffer",
+        "body": "Keep one refill ahead to avoid delays during supply shortages."
+      },
+      {
+        "level": "critical",
+        "title": "Confirm emergency contacts",
+        "body": "Ensure the plan lists who can step in if the primary caregiver is unavailable."
+      }
+    ]
+  },
+  "summary": {
+    "title": "Your cost summary",
+    "intro": "Here\u2019s the high-level view you can export for conversations.",
+    "table_headers": [
+      "Category",
+      "Monthly estimate"
+    ],
+    "actions": {
+      "download": "Download summary",
+      "share": "Share with advisor"
+    }
+  },
+  "confirm": {
+    "title": "Confirm and share",
+    "intro": "Double-check the plan and confirm you\u2019re ready to send it forward.",
+    "checklist": [
+      "I reviewed each drawer and captured key costs.",
+      "I noted any benefits or supports to explore further.",
+      "I\u2019m ready to loop in my advisor for next steps."
+    ],
+    "confirm_label": "I\u2019m ready to share this plan",
+    "share_button": "Share with my advisor",
+    "share_note": "A fun confetti moment will live here soon!"
+  },
+  "navi": {
+    "bubble_label": "Chat with Navi",
+    "quiet_message": "Navi is ready when you want more guidance.",
+    "suggestions": {
+      "chronic_conditions": {
+        "title": "Add prescription planning",
+        "body": "Because chronic conditions are on your radar, consider adding a buffer for new medications."
+      },
+      "owns_home": {
+        "title": "Track home utilities",
+        "body": "Since you own the home, include utilities so the budget covers true monthly costs."
+      },
+      "medicaid": {
+        "title": "Verify Medicaid eligibility",
+        "body": "Let\u2019s note to confirm Medicaid rules in your state\u2014eligibility can unlock big savings."
+      }
+    }
+  }
+}

--- a/guided_care_plan/labels.json
+++ b/guided_care_plan/labels.json
@@ -4,111 +4,246 @@
       "label": "How much help is needed with daily routines like bathing, dressing, and meal prep?",
       "description": "Covers activities of daily living and whether meals happen independently.",
       "options": [
-        {"value": "independent", "label": "I manage everything on my own"},
-        {"value": "light_support", "label": "I need reminders or light help"},
-        {"value": "moderate_support", "label": "I need help with several tasks"},
-        {"value": "extensive_support", "label": "I rely on others for most tasks"}
+        {
+          "value": "independent",
+          "label": "I manage everything on my own"
+        },
+        {
+          "value": "light_support",
+          "label": "I need reminders or light help"
+        },
+        {
+          "value": "moderate_support",
+          "label": "I need help with several tasks"
+        },
+        {
+          "value": "extensive_support",
+          "label": "I rely on others for most tasks"
+        }
       ]
     },
     "medication_management": {
       "label": "How are medications managed day to day?",
       "description": "Shows the risk for missed or incorrect doses.",
       "options": [
-        {"value": "self_managed", "label": "Handled independently"},
-        {"value": "uses_reminders", "label": "Managed with reminders or pill boxes"},
-        {"value": "needs_help", "label": "Someone usually sets them up"},
-        {"value": "high_risk", "label": "Frequently missed or mixed up"}
+        {
+          "value": "self_managed",
+          "label": "Handled independently"
+        },
+        {
+          "value": "uses_reminders",
+          "label": "Managed with reminders or pill boxes"
+        },
+        {
+          "value": "needs_help",
+          "label": "Someone usually sets them up"
+        },
+        {
+          "value": "high_risk",
+          "label": "Frequently missed or mixed up"
+        }
       ]
     },
     "caregiver_support": {
       "label": "How much consistent help is available from family or caregivers?",
       "description": "Helps balance support needs with available hands-on help.",
       "options": [
-        {"value": "robust", "label": "Support most days of the week"},
-        {"value": "intermittent", "label": "Help a few days each week"},
-        {"value": "limited", "label": "Occasional check-ins"},
-        {"value": "none", "label": "I mostly manage alone"}
+        {
+          "value": "robust",
+          "label": "Support most days of the week"
+        },
+        {
+          "value": "intermittent",
+          "label": "Help a few days each week"
+        },
+        {
+          "value": "limited",
+          "label": "Occasional check-ins"
+        },
+        {
+          "value": "none",
+          "label": "I mostly manage alone"
+        }
       ]
     },
     "falls_history": {
       "label": "Have there been any falls in the last 6 months?",
       "description": "Recent falls raise supervision and safety needs.",
       "options": [
-        {"value": "none", "label": "No falls"},
-        {"value": "one", "label": "One fall"},
-        {"value": "multiple", "label": "More than one"},
-        {"value": "unknown", "label": "Not sure"}
+        {
+          "value": "none",
+          "label": "No falls"
+        },
+        {
+          "value": "one",
+          "label": "One fall"
+        },
+        {
+          "value": "multiple",
+          "label": "More than one"
+        },
+        {
+          "value": "unknown",
+          "label": "Not sure"
+        }
       ]
     },
     "cognition": {
       "label": "How would you describe memory and thinking on a typical day?",
       "description": "Combines with medication management to gauge supervision.",
       "options": [
-        {"value": "clear", "label": "Clear and consistent"},
-        {"value": "mild_changes", "label": "Some forgetfulness"},
-        {"value": "moderate_changes", "label": "Frequent confusion"},
-        {"value": "significant_changes", "label": "Serious memory loss or confusion"}
+        {
+          "value": "clear",
+          "label": "Clear and consistent"
+        },
+        {
+          "value": "mild_changes",
+          "label": "Some forgetfulness"
+        },
+        {
+          "value": "moderate_changes",
+          "label": "Frequent confusion"
+        },
+        {
+          "value": "significant_changes",
+          "label": "Serious memory loss or confusion"
+        }
       ]
     },
     "behavior_signals": {
       "label": "Are there behaviors like wandering, aggression, or sundowning?",
       "description": "Flags that point toward memory care supports.",
       "options": [
-        {"value": "none", "label": "No concerning behaviors"},
-        {"value": "occasional", "label": "Occasional changes"},
-        {"value": "frequent", "label": "Frequent or escalating"},
-        {"value": "high_risk", "label": "High-risk behaviors or wandering"}
+        {
+          "value": "none",
+          "label": "No concerning behaviors"
+        },
+        {
+          "value": "occasional",
+          "label": "Occasional changes"
+        },
+        {
+          "value": "frequent",
+          "label": "Frequent or escalating"
+        },
+        {
+          "value": "high_risk",
+          "label": "High-risk behaviors or wandering"
+        }
       ]
     },
     "supervision_need": {
       "label": "How much supervision is needed during the day or overnight?",
       "description": "Helps right-size the care setting.",
       "options": [
-        {"value": "minimal", "label": "Check-ins are enough"},
-        {"value": "daytime", "label": "Support most days"},
-        {"value": "extended", "label": "Support most of the day"},
-        {"value": "around_clock", "label": "Support is needed day and night"}
+        {
+          "value": "minimal",
+          "label": "Check-ins are enough"
+        },
+        {
+          "value": "daytime",
+          "label": "Support most days"
+        },
+        {
+          "value": "extended",
+          "label": "Support most of the day"
+        },
+        {
+          "value": "around_clock",
+          "label": "Support is needed day and night"
+        }
       ]
     },
     "living_situation": {
       "label": "Where does care happen today?",
       "description": "Aligns the plan with the current living setup.",
       "options": [
-        {"value": "alone", "label": "Living alone"},
-        {"value": "with_partner", "label": "Living with a partner"},
-        {"value": "with_family", "label": "Living with family"},
-        {"value": "community", "label": "Already in a care community"}
+        {
+          "value": "alone",
+          "label": "Living alone"
+        },
+        {
+          "value": "with_partner",
+          "label": "Living with a partner"
+        },
+        {
+          "value": "with_family",
+          "label": "Living with family"
+        },
+        {
+          "value": "community",
+          "label": "Already in a care community"
+        }
       ]
     },
     "partner_support": {
       "label": "How involved is a partner in day-to-day care?",
       "description": "Only shown when a partner is in the picture.",
       "options": [
-        {"value": "primary_caregiver", "label": "My partner is the primary caregiver"},
-        {"value": "shared_care", "label": "We share the responsibilities"},
-        {"value": "needs_support", "label": "My partner needs backup"},
-        {"value": "no_partner", "label": "No partner involved"}
+        {
+          "value": "primary_caregiver",
+          "label": "My partner is the primary caregiver"
+        },
+        {
+          "value": "shared_care",
+          "label": "We share the responsibilities"
+        },
+        {
+          "value": "needs_support",
+          "label": "My partner needs backup"
+        },
+        {
+          "value": "no_partner",
+          "label": "No partner involved"
+        }
       ]
     },
     "home_safety": {
       "label": "How safe and manageable is the current home?",
       "description": "Shown when the household owns the home.",
       "options": [
-        {"value": "ready", "label": "Set up with safety features"},
-        {"value": "minor_updates", "label": "Needs a few updates"},
-        {"value": "major_updates", "label": "Needs significant updates"},
-        {"value": "not_feasible", "label": "Home does not fit long-term needs"},
-        {"value": "not_homeowner", "label": "We do not own this home"}
+        {
+          "value": "ready",
+          "label": "Set up with safety features"
+        },
+        {
+          "value": "minor_updates",
+          "label": "Needs a few updates"
+        },
+        {
+          "value": "major_updates",
+          "label": "Needs significant updates"
+        },
+        {
+          "value": "not_feasible",
+          "label": "Home does not fit long-term needs"
+        },
+        {
+          "value": "not_homeowner",
+          "label": "We do not own this home"
+        }
       ]
     },
     "veteran_benefits": {
       "label": "Do you want help using VA or military-connected benefits?",
       "description": "Appears only for veterans.",
       "options": [
-        {"value": "actively_using", "label": "Already using benefits"},
-        {"value": "need_help", "label": "Need help understanding options"},
-        {"value": "not_interested", "label": "Not interested right now"},
-        {"value": "not_applicable", "label": "Not a veteran"}
+        {
+          "value": "actively_using",
+          "label": "Already using benefits"
+        },
+        {
+          "value": "need_help",
+          "label": "Need help understanding options"
+        },
+        {
+          "value": "not_interested",
+          "label": "Not interested right now"
+        },
+        {
+          "value": "not_applicable",
+          "label": "Not a veteran"
+        }
       ]
     },
     "chronic_conditions": {
@@ -123,6 +258,50 @@
         "Parkinson's",
         "Dementia or Alzheimer's",
         "None"
+      ]
+    },
+    "medicaid_status": {
+      "label": "How confident are you about Medicaid eligibility?",
+      "description": "Helps us surface the right planning checklists.",
+      "options": [
+        {
+          "value": "eligible",
+          "label": "We know we qualify"
+        },
+        {
+          "value": "in_progress",
+          "label": "We are applying or appealing"
+        },
+        {
+          "value": "unsure",
+          "label": "We need help figuring it out"
+        },
+        {
+          "value": "not_applicable",
+          "label": "Not applicable"
+        }
+      ]
+    },
+    "funding_confidence": {
+      "label": "How confident do you feel in covering near-term costs?",
+      "description": "Guides which reassurance tips Navi offers.",
+      "options": [
+        {
+          "value": "steady",
+          "label": "We\u2019re on track"
+        },
+        {
+          "value": "monitoring",
+          "label": "We\u2019re watching things closely"
+        },
+        {
+          "value": "uncertain",
+          "label": "We could use more support"
+        },
+        {
+          "value": "urgent",
+          "label": "We\u2019re worried about the next few months"
+        }
       ]
     }
   }

--- a/senior_nav/components/__init__.py
+++ b/senior_nav/components/__init__.py
@@ -1,0 +1,14 @@
+"""Convenience exports for shared UI components."""
+from __future__ import annotations
+
+from . import banners, card, formbits, layout, nav, stepper, theme
+
+__all__ = [
+    "banners",
+    "card",
+    "formbits",
+    "layout",
+    "nav",
+    "stepper",
+    "theme",
+]

--- a/senior_nav/components/banners.py
+++ b/senior_nav/components/banners.py
@@ -1,0 +1,36 @@
+"""Banner helpers for inline alerts."""
+from __future__ import annotations
+
+import streamlit as st
+
+_LEVEL_CLASS = {
+    "info": "sn-banner--info",
+    "warning": "sn-banner--warning",
+    "critical": "sn-banner--warning",
+    "success": "sn-banner--success",
+}
+
+_LEVEL_ICON = {
+    "info": "💡",
+    "warning": "⚠️",
+    "critical": "❗",
+    "success": "✅",
+}
+
+
+def render(level: str, title: str, body: str) -> None:
+    """Render a banner with semantic styling."""
+    css_class = _LEVEL_CLASS.get(level, "sn-banner--info")
+    icon = _LEVEL_ICON.get(level, "💡")
+    st.markdown(
+        f"""
+        <div class="sn-banner {css_class}">
+          <div class="sn-banner__icon">{icon}</div>
+          <div class="sn-banner__content">
+            <h4>{title}</h4>
+            <p>{body}</p>
+          </div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )

--- a/senior_nav/components/card.py
+++ b/senior_nav/components/card.py
@@ -1,0 +1,82 @@
+"""Card helpers for high-fidelity UI shells."""
+from __future__ import annotations
+
+from typing import Callable
+
+import streamlit as st
+
+
+def _inject_card_styles() -> None:
+    if st.session_state.get("__sn_card_styles__"):
+        return
+    st.session_state["__sn_card_styles__"] = True
+    st.markdown(
+        """
+        <style>
+        .sn-card__surface {
+          background: var(--sn-color-bg);
+          border: 1px solid var(--sn-color-border);
+          border-radius: var(--sn-radius-lg);
+          padding: var(--sn-spacing-xl);
+          box-shadow: var(--sn-shadow-soft);
+          display: flex;
+          flex-direction: column;
+          gap: var(--sn-spacing-md);
+          min-height: 100%;
+        }
+        .sn-card__title {
+          font-size: var(--sn-type-h2-size);
+          font-weight: var(--sn-type-h2-weight);
+          margin: 0;
+        }
+        .sn-card__body {
+          color: rgba(17, 20, 24, 0.72);
+          flex: 1;
+        }
+        .sn-card__cta {
+          width: fit-content;
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def render_basic(title: str, body: str | None = None, footer: str | None = None) -> None:
+    """Render a static informational card."""
+    _inject_card_styles()
+    st.markdown(
+        f"""
+        <div class="sn-card__surface">
+          <h3 class="sn-card__title">{title}</h3>
+          {f'<p class="sn-card__body">{body}</p>' if body else ''}
+          {f'<div class="sn-card__footer">{footer}</div>' if footer else ''}
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def render_action(
+    title: str,
+    body: str,
+    button_label: str,
+    key: str,
+    *,
+    on_click: Callable[[], None],
+    disabled: bool = False,
+) -> None:
+    """Render a call-to-action card with a button."""
+    _inject_card_styles()
+    placeholder = st.container()
+    with placeholder:
+        st.markdown(
+            f"""
+            <div class=\"sn-card__surface\">
+              <h3 class=\"sn-card__title\">{title}</h3>
+              <p class=\"sn-card__body\">{body}</p>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+        st.button(button_label, key=key, on_click=on_click, disabled=disabled)

--- a/senior_nav/components/formbits.py
+++ b/senior_nav/components/formbits.py
@@ -1,0 +1,51 @@
+"""Shared form helpers for the cost planner UI."""
+from __future__ import annotations
+
+from typing import Mapping
+
+import streamlit as st
+
+
+def choice_group(
+    label: str,
+    options: Mapping[str, str],
+    *,
+    key: str,
+    default: str | None = None,
+    horizontal: bool = False,
+) -> str:
+    """Render a radio choice using friendly labels."""
+    keys = list(options.keys())
+    if default is None:
+        default = keys[0]
+    return st.radio(
+        label,
+        options=keys,
+        format_func=lambda value: options[value],
+        key=key,
+        index=keys.index(default) if default in keys else 0,
+        horizontal=horizontal,
+    )
+
+
+def text_input(label: str, *, key: str, placeholder: str | None = None) -> str:
+    """Render a text input."""
+    return st.text_input(label, key=key, placeholder=placeholder or "")
+
+
+def currency_input(label: str, *, key: str) -> str:
+    """Render a simple currency text input (UI only)."""
+    return st.text_input(label, key=key, placeholder="$0")
+
+
+def checklist(options: list[str], *, key_prefix: str) -> dict[str, bool]:
+    """Render a list of checkboxes and return their state."""
+    state: dict[str, bool] = {}
+    for idx, item in enumerate(options):
+        state[item] = st.checkbox(item, key=f"{key_prefix}_{idx}")
+    return state
+
+
+def confirmation_checkbox(label: str, *, key: str) -> bool:
+    """Render a confirmation checkbox."""
+    return st.checkbox(label, key=key)

--- a/senior_nav/components/layout.py
+++ b/senior_nav/components/layout.py
@@ -1,0 +1,119 @@
+"""Layout helpers for the cost planner shell."""
+from __future__ import annotations
+
+from typing import Iterable
+
+import streamlit as st
+
+from . import stepper
+
+
+def _inject_layout_styles() -> None:
+    if st.session_state.get("__sn_layout_styles__"):
+        return
+    st.session_state["__sn_layout_styles__"] = True
+    st.markdown(
+        """
+        <style>
+        .sn-mode-badge {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.5rem;
+          padding: 0.35rem 0.85rem;
+          border-radius: 999px;
+          background: rgba(43, 118, 229, 0.12);
+          color: var(--sn-color-primary);
+          font-weight: 600;
+          font-size: 0.85rem;
+        }
+        .sn-progress-label {
+          font-size: var(--sn-type-small-size);
+          color: rgba(17, 20, 24, 0.6);
+          margin-bottom: 0.25rem;
+        }
+        .sn-drawer-summary {
+          background: var(--sn-color-bg-subtle);
+          border-radius: var(--sn-radius-lg);
+          padding: var(--sn-spacing-lg);
+          border: 1px dashed var(--sn-color-border);
+        }
+        .sn-drawer-summary h4 {
+          margin: 0 0 var(--sn-spacing-xs) 0;
+        }
+        .sn-sidebar-card {
+          background: var(--sn-color-bg);
+          border-radius: var(--sn-radius-lg);
+          border: 1px solid var(--sn-color-border);
+          padding: var(--sn-spacing-lg);
+          box-shadow: var(--sn-shadow-soft);
+        }
+        .sn-sidebar-card h4 {
+          margin-top: 0;
+          margin-bottom: var(--sn-spacing-sm);
+        }
+        .sn-sidebar-list {
+          list-style: none;
+          padding: 0;
+          margin: 0;
+          display: grid;
+          gap: 0.35rem;
+        }
+        .sn-sidebar-list li {
+          display: flex;
+          justify-content: space-between;
+          font-size: var(--sn-type-body-size);
+        }
+        .sn-sidebar-divider {
+          border-top: 1px dashed var(--sn-color-border);
+          margin: var(--sn-spacing-md) 0;
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def render_header(title: str, badge_text: str, steps: Iterable[str], current_index: int, *, progress: float, progress_label: str) -> None:
+    """Render the shell header with title, badge, stepper, and progress."""
+    _inject_layout_styles()
+    col_title, col_badge = st.columns([4, 1])
+    with col_title:
+        st.markdown(f"<h1>{title}</h1>", unsafe_allow_html=True)
+    with col_badge:
+        st.markdown(f"<span class='sn-mode-badge'>{badge_text}</span>", unsafe_allow_html=True)
+    stepper.render(steps, current_index)
+    st.markdown(f"<div class='sn-progress-label'>{progress_label}</div>", unsafe_allow_html=True)
+    st.progress(progress)
+
+
+def render_sidebar(totals_title: str, rows: list[list[str]], navi_title: str, navi_body: str) -> None:
+    """Render the sidebar summary card."""
+    _inject_layout_styles()
+    st.markdown(
+        f"""
+        <div class="sn-sidebar-card">
+          <h4>{totals_title}</h4>
+          <ul class="sn-sidebar-list">
+            {''.join(f'<li><span>{label}</span><strong>{value}</strong></li>' for label, value in rows)}
+          </ul>
+          <div class="sn-sidebar-divider"></div>
+          <p style="margin:0; color: rgba(17, 20, 24, 0.72);">{navi_title}</p>
+          <p style="margin:0; color: rgba(17, 20, 24, 0.6);">{navi_body}</p>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def render_drawer_summary(label: str, subtotal: str, hint: str) -> None:
+    """Render the mini summary box for drawers."""
+    _inject_layout_styles()
+    st.markdown(
+        f"""
+        <div class="sn-drawer-summary">
+          <h4>{label}: {subtotal}</h4>
+          <p style="margin:0; color: rgba(17, 20, 24, 0.6);">{hint}</p>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )

--- a/senior_nav/components/stepper.py
+++ b/senior_nav/components/stepper.py
@@ -1,0 +1,21 @@
+"""Render a lightweight progress stepper."""
+from __future__ import annotations
+
+from typing import Iterable
+
+import streamlit as st
+
+
+def render(labels: Iterable[str], current_index: int) -> None:
+    """Render the cost planner stepper as a static visual."""
+    items = list(labels)
+    html_parts = ["<ul class=\"sn-stepper\">"]
+    for idx, label in enumerate(items, start=1):
+        css_class = "sn-stepper__item"
+        if idx - 1 == current_index:
+            css_class += " is-active"
+        html_parts.append(
+            f"<li class=\"{css_class}\" data-step=\"{idx}\">{label}</li>"
+        )
+    html_parts.append("</ul>")
+    st.markdown("\n".join(html_parts), unsafe_allow_html=True)

--- a/senior_nav/cost_planner/__init__.py
+++ b/senior_nav/cost_planner/__init__.py
@@ -1,0 +1,6 @@
+"""Cost planner helpers."""
+from __future__ import annotations
+
+from . import nav, state, wizard
+
+__all__ = ["nav", "state", "wizard"]

--- a/senior_nav/cost_planner/nav.py
+++ b/senior_nav/cost_planner/nav.py
@@ -1,0 +1,26 @@
+"""Navigation helpers for the cost planner wizard."""
+from __future__ import annotations
+
+from . import state, wizard
+
+
+def go_to(index: int) -> None:
+    wizard.set_current_step(index)
+
+
+def go_next() -> None:
+    current = state.get_progress()
+    wizard.set_current_step(current + 1)
+
+
+def go_previous() -> None:
+    current = state.get_progress()
+    wizard.set_current_step(max(0, current - 1))
+
+
+def mark_drawer_complete(drawer_key: str) -> None:
+    state.set_drawer_status(drawer_key, "done")
+
+
+def mark_drawer_open(drawer_key: str) -> None:
+    state.set_drawer_status(drawer_key, "in_progress")

--- a/senior_nav/cost_planner/state.py
+++ b/senior_nav/cost_planner/state.py
@@ -1,0 +1,88 @@
+"""Session state helpers for the cost planner wizard."""
+from __future__ import annotations
+
+import copy
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict
+
+import streamlit as st
+
+_DEFAULT_STATE: Dict[str, Any] = {
+    "mode": "exploring",
+    "qualifiers": {
+        "contribution_style": "unified",
+        "contributors": [],
+        "owns_home": None,
+        "is_veteran": None,
+    },
+    "drawer_status": {
+        "housing": "start",
+        "care": "start",
+        "medical": "start",
+        "insurance_benefits": "start",
+        "debts_other": "start",
+    },
+    "ui": {
+        "progress": 0,
+        "suggestions_shown": set(),
+    },
+}
+
+
+def ensure_state() -> None:
+    """Ensure the cost planner state exists in ``st.session_state``."""
+    if "cp" not in st.session_state:
+        st.session_state["cp"] = copy.deepcopy(_DEFAULT_STATE)
+    ui = st.session_state["cp"].setdefault("ui", {})
+    if not isinstance(ui.get("suggestions_shown"), set):
+        ui["suggestions_shown"] = set(ui.get("suggestions_shown", []))
+
+
+def get_state() -> Dict[str, Any]:
+    ensure_state()
+    return st.session_state["cp"]
+
+
+def get_flags() -> Dict[str, Any]:
+    return st.session_state.get("flags", {})
+
+
+def get_gcp_state() -> Dict[str, Any]:
+    return st.session_state.get("gcp", {})
+
+
+def get_progress() -> int:
+    return get_state()["ui"].get("progress", 0)
+
+
+def set_progress(index: int) -> None:
+    state = get_state()
+    state["ui"]["progress"] = max(0, index)
+
+
+def set_mode(mode: str) -> None:
+    get_state()["mode"] = mode
+
+
+def update_qualifier(key: str, value: Any) -> None:
+    get_state()["qualifiers"][key] = value
+
+
+def set_drawer_status(key: str, status: str) -> None:
+    get_state()["drawer_status"][key] = status
+
+
+def mark_suggestions_seen(suggestion_ids: set[str]) -> None:
+    if not suggestion_ids:
+        return
+    seen = get_state()["ui"].setdefault("suggestions_shown", set())
+    seen.update(suggestion_ids)
+
+
+@lru_cache(maxsize=1)
+def get_copy() -> Dict[str, Any]:
+    """Load and cache the cost planner copy."""
+    path = Path("copy/cost_planner_strings.json")
+    return json.loads(path.read_text())

--- a/senior_nav/cost_planner/wizard.py
+++ b/senior_nav/cost_planner/wizard.py
@@ -1,0 +1,76 @@
+"""Wizard registry and loader for the cost planner."""
+from __future__ import annotations
+
+import importlib.util
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Callable, List
+
+from . import state
+
+
+@dataclass(frozen=True)
+class Step:
+    key: str
+    label: str
+    path: str
+    drawer_key: str | None = None
+
+
+STEPS: List[Step] = [
+    Step("mode", "Mode", "ui/pages/cp/00_mode_selection.py"),
+    Step("qualifiers", "Qualifiers", "ui/pages/cp/01_qualifiers.py"),
+    Step("housing", "Housing", "ui/pages/cp/10_housing.py", drawer_key="housing"),
+    Step("care", "Care", "ui/pages/cp/20_care.py", drawer_key="care"),
+    Step("medical", "Medical", "ui/pages/cp/30_medical.py", drawer_key="medical"),
+    Step(
+        "insurance_benefits",
+        "Insurance & Benefits",
+        "ui/pages/cp/40_insurance_benefits.py",
+        drawer_key="insurance_benefits",
+    ),
+    Step("debts_other", "Debts & Other", "ui/pages/cp/50_debts_other.py", drawer_key="debts_other"),
+    Step("review", "Review", "ui/pages/cp/60_review.py"),
+    Step("summary", "Summary", "ui/pages/cp/70_summary.py"),
+    Step("confirm", "Confirm", "ui/pages/cp/80_confirm.py"),
+]
+
+
+def get_steps() -> List[Step]:
+    return STEPS
+
+
+def get_current_step() -> Step:
+    index = max(0, min(state.get_progress(), len(STEPS) - 1))
+    return STEPS[index]
+
+
+def get_step_index(step: Step) -> int:
+    return STEPS.index(step)
+
+
+def set_current_step(index: int) -> None:
+    capped = max(0, min(index, len(STEPS) - 1))
+    state.set_progress(capped)
+
+
+@lru_cache(maxsize=None)
+def load_step_module(step: Step):
+    """Dynamically load the module for a step."""
+    path = Path(step.path)
+    module_name = "cp_" + "_".join(path.with_suffix("").parts)
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load step module at {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def run_step(step: Step) -> None:
+    module = load_step_module(step)
+    render: Callable[[], None] | None = getattr(module, "render", None)
+    if render is None:
+        raise AttributeError(f"Step module {step.path} must define a render() function")
+    render()

--- a/senior_nav/navi/__init__.py
+++ b/senior_nav/navi/__init__.py
@@ -1,0 +1,6 @@
+"""Navi assistant package."""
+from __future__ import annotations
+
+from . import agent
+
+__all__ = ["agent"]

--- a/senior_nav/navi/agent.py
+++ b/senior_nav/navi/agent.py
@@ -1,0 +1,129 @@
+"""Mock Navi assistant for the cost planner UI."""
+from __future__ import annotations
+
+from typing import Iterable, Tuple
+
+import streamlit as st
+
+from senior_nav.cost_planner import state
+
+
+def _inject_styles() -> None:
+    if st.session_state.get("__navi_styles__"):
+        return
+    st.session_state["__navi_styles__"] = True
+    st.markdown(
+        """
+        <style>
+        .navi-shell {
+          position: fixed;
+          right: 32px;
+          bottom: 32px;
+          z-index: 999;
+          display: flex;
+          flex-direction: column;
+          align-items: flex-end;
+          gap: 12px;
+        }
+        .navi-panel {
+          width: 320px;
+          background: var(--sn-color-bg);
+          border-radius: var(--sn-radius-lg);
+          border: 1px solid var(--sn-color-border);
+          box-shadow: var(--sn-shadow-soft);
+          padding: var(--sn-spacing-lg);
+        }
+        .navi-panel h4 {
+          margin-top: 0;
+          margin-bottom: var(--sn-spacing-sm);
+        }
+        .navi-panel__item + .navi-panel__item {
+          margin-top: var(--sn-spacing-sm);
+          padding-top: var(--sn-spacing-sm);
+          border-top: 1px dashed var(--sn-color-border);
+        }
+        .navi-bubble {
+          background: var(--sn-color-primary);
+          color: white;
+          padding: 0.75rem 1.2rem;
+          border-radius: 999px;
+          font-weight: 600;
+          box-shadow: var(--sn-shadow-soft);
+        }
+        .navi-bubble--quiet {
+          background: rgba(43, 118, 229, 0.2);
+          color: var(--sn-color-primary);
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def _determine_suggestions(drawer_key: str | None) -> Iterable[Tuple[str, dict[str, str]]]:
+    copy = state.get_copy()["navi"]["suggestions"]
+    cp_state = state.get_state()
+    gcp_state = state.get_gcp_state()
+    flags = state.get_flags()
+
+    if gcp_state.get("chronic_conditions"):
+        yield "chronic_conditions", copy["chronic_conditions"]
+    if (
+        cp_state["qualifiers"].get("owns_home") is True
+        and drawer_key == "housing"
+        and cp_state["drawer_status"].get("housing") == "start"
+    ):
+        yield "owns_home", copy["owns_home"]
+    if flags.get("medicaid_unsure"):
+        yield "medicaid", copy["medicaid"]
+
+
+def render(drawer_key: str | None) -> None:
+    """Render Navi bubble and suggestion panel."""
+    _inject_styles()
+    copy = state.get_copy()["navi"]
+    cp_state = state.get_state()
+    suggestions = list(_determine_suggestions(drawer_key))
+    seen = cp_state["ui"].get("suggestions_shown", set())
+    suggestion_ids = {f"{drawer_key or 'global'}:{key}" for key, _ in suggestions}
+    unseen = suggestion_ids.difference(seen)
+
+    panel_should_open = cp_state.get("mode") == "planning" and bool(unseen)
+    if panel_should_open:
+        state.mark_suggestions_seen(unseen)
+
+    bubble_classes = "navi-bubble"
+    bubble_text = copy["bubble_label"]
+    if cp_state.get("mode") != "planning" or not suggestions:
+        bubble_classes += " navi-bubble--quiet"
+        bubble_text = copy["quiet_message"]
+
+    panel_html = ""
+    if panel_should_open and suggestions:
+        items_html = "".join(
+            f"""
+            <div class=\"navi-panel__item\">
+              <strong>{item['title']}</strong>
+              <p style='margin:0.35rem 0 0 0; color: rgba(17,20,24,0.72);'>{item['body']}</p>
+            </div>
+            """
+            for _, item in suggestions
+        )
+        panel_html = (
+            f"""
+            <div class=\"navi-panel\">
+              <h4>Navi suggests</h4>
+              {items_html}
+            </div>
+            """
+        )
+
+    st.markdown(
+        f"""
+        <div class=\"navi-shell\">
+          {panel_html}
+          <div class=\"{bubble_classes}\">{bubble_text}</div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )

--- a/tests/test_cp_design_lint.py
+++ b/tests/test_cp_design_lint.py
@@ -1,0 +1,23 @@
+"""Lint checks for cost planner design assets."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def test_cost_planner_copy_file_exists() -> None:
+    copy_path = Path("copy/cost_planner_strings.json")
+    assert copy_path.exists(), "Cost planner copy file missing"
+    data = json.loads(copy_path.read_text())
+    assert "app" in data and "mode_selection" in data, "Copy file missing expected sections"
+
+
+def test_labels_include_medicaid_and_funding() -> None:
+    labels_path = Path("guided_care_plan/labels.json")
+    labels = json.loads(labels_path.read_text())
+    questions = labels.get("questions", {})
+    assert "medicaid_status" in questions, "medicaid_status question missing"
+    assert "funding_confidence" in questions, "funding_confidence question missing"

--- a/tests/test_cp_ui_paths.py
+++ b/tests/test_cp_ui_paths.py
@@ -1,0 +1,17 @@
+"""Ensure cost planner pages are importable."""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from senior_nav.cost_planner import wizard
+
+
+def test_cp_step_modules_define_render() -> None:
+    for step in wizard.STEPS:
+        path = Path(step.path)
+        assert path.exists(), f"Step file missing: {path}"
+        module = wizard.load_step_module(step)
+        assert hasattr(module, "render"), f"Step {step.key} missing render()"

--- a/ui/pages/03_cost_planner.py
+++ b/ui/pages/03_cost_planner.py
@@ -1,12 +1,47 @@
-"""Placeholder for the Cost Planner intro page."""
+"""Cost planner hi-fi shell with wizard wiring."""
 from __future__ import annotations
 
 import streamlit as st
 
-from senior_nav.components.theme import inject_theme
+from senior_nav.components import layout, theme
+from senior_nav.cost_planner import state, wizard
+from senior_nav.navi import agent as navi_agent
 
+state.ensure_state()
 st.set_page_config(layout="wide")
-inject_theme()
+theme.inject_theme()
 
-st.title("Cost Planner")
-st.info("Cost Planner shell will be wired in a subsequent pass.")
+copy = state.get_copy()
+app_copy = copy["app"]
+steps = wizard.get_steps()
+current_step = wizard.get_current_step()
+current_index = wizard.get_step_index(current_step)
+progress_ratio = current_index / (len(steps) - 1) if len(steps) > 1 else 0
+mode_badge = app_copy["mode_badges"].get(
+    state.get_state().get("mode", "exploring"),
+    app_copy["mode_badges"]["exploring"],
+)
+
+layout.render_header(
+    app_copy["title"],
+    mode_badge,
+    [step.label for step in steps],
+    current_index,
+    progress=progress_ratio,
+    progress_label=app_copy["progress_label"],
+)
+
+main_col, sidebar_col = st.columns([3, 1])
+with main_col:
+    wizard.run_step(current_step)
+
+with sidebar_col:
+    sidebar = app_copy["sidebar"]
+    layout.render_sidebar(
+        sidebar["totals_title"],
+        sidebar["totals_rows"],
+        sidebar["navi_title"],
+        sidebar["navi_body"],
+    )
+
+navi_agent.render(current_step.drawer_key)

--- a/ui/pages/cp/00_mode_selection.py
+++ b/ui/pages/cp/00_mode_selection.py
@@ -1,0 +1,60 @@
+"""Mode selection step for the cost planner."""
+from __future__ import annotations
+
+import streamlit as st
+
+from senior_nav.components import card
+from senior_nav.cost_planner import nav, state
+
+
+def _open_login_modal() -> None:
+    st.session_state["__cp_show_login_modal__"] = True
+
+
+def render() -> None:
+    copy = state.get_copy()
+    mode_copy = copy["mode_selection"]
+
+    st.markdown(f"### {mode_copy['headline']}")
+
+    cards = mode_copy["cards"]
+    col_explore, col_plan = st.columns(2)
+
+    with col_explore:
+        card.render_action(
+            cards["explore"]["title"],
+            cards["explore"]["body"],
+            cards["explore"]["cta"],
+            key="cp_mode_explore",
+            on_click=_select_exploring,
+        )
+
+    with col_plan:
+        card.render_action(
+            cards["plan"]["title"],
+            cards["plan"]["body"],
+            cards["plan"]["cta"],
+            key="cp_mode_plan",
+            on_click=_open_login_modal,
+        )
+
+    if st.session_state.get("__cp_show_login_modal__"):
+        modal = mode_copy["login_modal"]
+        with st.modal(modal["title"]):
+            st.write(modal["body"])
+            if st.button(modal["confirm"], key="cp_login_confirm"):
+                st.session_state["__cp_show_login_modal__"] = False
+                _set_mode("planning")
+                nav.go_next()
+
+
+def _set_mode(mode: str) -> None:
+    state.set_mode(mode)
+    if mode == "exploring":
+        # Reset suggestions so exploring mode stays quiet.
+        state.get_state()["ui"].setdefault("suggestions_shown", set()).clear()
+
+
+def _select_exploring() -> None:
+    _set_mode("exploring")
+    nav.go_next()

--- a/ui/pages/cp/01_qualifiers.py
+++ b/ui/pages/cp/01_qualifiers.py
@@ -1,0 +1,58 @@
+"""Qualifiers step to tailor drawer visibility."""
+from __future__ import annotations
+
+import streamlit as st
+
+from senior_nav.components import banners, formbits
+from senior_nav.cost_planner import nav, state
+
+
+def render() -> None:
+    copy = state.get_copy()
+    qualifiers_copy = copy["qualifiers"]
+    app_copy = copy["app"]
+    flags = state.get_flags()
+    cp_state = state.get_state()
+
+    st.markdown(f"### {qualifiers_copy['title']}")
+    st.write(qualifiers_copy["description"])
+
+    with st.form("cp_qualifiers_form"):
+        contribution = formbits.choice_group(
+            qualifiers_copy["contribution_style"]["label"],
+            qualifiers_copy["contribution_style"]["options"],
+            key="cp_contribution_style",
+            default=cp_state["qualifiers"].get("contribution_style", "unified"),
+        )
+        owns_home = formbits.choice_group(
+            qualifiers_copy["owns_home"]["label"],
+            qualifiers_copy["owns_home"]["options"],
+            key="cp_owns_home",
+            default="yes" if cp_state["qualifiers"].get("owns_home") else "no",
+            horizontal=True,
+        )
+        is_veteran = formbits.choice_group(
+            qualifiers_copy["is_veteran"]["label"],
+            qualifiers_copy["is_veteran"]["options"],
+            key="cp_is_veteran",
+            default="yes" if cp_state["qualifiers"].get("is_veteran") else "no",
+            horizontal=True,
+        )
+
+        submitted = st.form_submit_button(qualifiers_copy["continue"])
+
+    if flags.get("medicaid_unsure"):
+        banner = qualifiers_copy["medicaid_banner"]
+        banners.render("info", banner["title"], banner["body"])
+
+    back_col, next_col = st.columns([1, 1])
+    with back_col:
+        st.button(app_copy["navigation"]["back"], key="cp_qual_back", on_click=nav.go_previous)
+    with next_col:
+        if submitted:
+            state.update_qualifier("contribution_style", contribution)
+            state.update_qualifier("owns_home", owns_home == "yes")
+            state.update_qualifier("is_veteran", is_veteran == "yes")
+            nav.go_next()
+        else:
+            st.write(" ")

--- a/ui/pages/cp/10_housing.py
+++ b/ui/pages/cp/10_housing.py
@@ -1,0 +1,48 @@
+"""Housing drawer UI."""
+from __future__ import annotations
+
+import streamlit as st
+
+from senior_nav.components import formbits, layout
+from senior_nav.cost_planner import nav, state
+
+DRAWER_KEY = "housing"
+
+
+def render() -> None:
+    copy = state.get_copy()
+    drawer_copy = copy["drawers"][DRAWER_KEY]
+    app_copy = copy["app"]
+    state.ensure_state()
+    nav.mark_drawer_open(DRAWER_KEY)
+
+    st.markdown(f"### {drawer_copy['title']}")
+    st.caption(drawer_copy["caption"])
+
+    qualifiers = state.get_state()["qualifiers"]
+    hidden_fields = set()
+    if qualifiers.get("owns_home") is False:
+        hidden_fields.update({"maintenance", "home_modifications"})
+
+    with st.form(f"cp_{DRAWER_KEY}_form"):
+        for field_key, label in drawer_copy["fields"].items():
+            if field_key in hidden_fields:
+                continue
+            formbits.currency_input(label, key=f"cp_{DRAWER_KEY}_{field_key}")
+        submitted = st.form_submit_button(app_copy["navigation"]["continue"])
+
+    layout.render_drawer_summary(
+        app_copy["drawer_summary_label"],
+        drawer_copy["subtotal"],
+        drawer_copy["summary_hint"],
+    )
+
+    back_col, next_col = st.columns([1, 1])
+    with back_col:
+        st.button(app_copy["navigation"]["back"], key="cp_housing_back", on_click=nav.go_previous)
+    with next_col:
+        if submitted:
+            nav.mark_drawer_complete(DRAWER_KEY)
+            nav.go_next()
+        else:
+            st.write(" ")

--- a/ui/pages/cp/20_care.py
+++ b/ui/pages/cp/20_care.py
@@ -1,0 +1,40 @@
+"""Care drawer UI."""
+from __future__ import annotations
+
+import streamlit as st
+
+from senior_nav.components import formbits, layout
+from senior_nav.cost_planner import nav, state
+
+DRAWER_KEY = "care"
+
+
+def render() -> None:
+    copy = state.get_copy()
+    drawer_copy = copy["drawers"][DRAWER_KEY]
+    app_copy = copy["app"]
+    nav.mark_drawer_open(DRAWER_KEY)
+
+    st.markdown(f"### {drawer_copy['title']}")
+    st.caption(drawer_copy["caption"])
+
+    with st.form(f"cp_{DRAWER_KEY}_form"):
+        for field_key, label in drawer_copy["fields"].items():
+            formbits.currency_input(label, key=f"cp_{DRAWER_KEY}_{field_key}")
+        submitted = st.form_submit_button(app_copy["navigation"]["continue"])
+
+    layout.render_drawer_summary(
+        app_copy["drawer_summary_label"],
+        drawer_copy["subtotal"],
+        drawer_copy["summary_hint"],
+    )
+
+    back_col, next_col = st.columns([1, 1])
+    with back_col:
+        st.button(app_copy["navigation"]["back"], key="cp_care_back", on_click=nav.go_previous)
+    with next_col:
+        if submitted:
+            nav.mark_drawer_complete(DRAWER_KEY)
+            nav.go_next()
+        else:
+            st.write(" ")

--- a/ui/pages/cp/30_medical.py
+++ b/ui/pages/cp/30_medical.py
@@ -1,0 +1,40 @@
+"""Medical drawer UI."""
+from __future__ import annotations
+
+import streamlit as st
+
+from senior_nav.components import formbits, layout
+from senior_nav.cost_planner import nav, state
+
+DRAWER_KEY = "medical"
+
+
+def render() -> None:
+    copy = state.get_copy()
+    drawer_copy = copy["drawers"][DRAWER_KEY]
+    app_copy = copy["app"]
+    nav.mark_drawer_open(DRAWER_KEY)
+
+    st.markdown(f"### {drawer_copy['title']}")
+    st.caption(drawer_copy["caption"])
+
+    with st.form(f"cp_{DRAWER_KEY}_form"):
+        for field_key, label in drawer_copy["fields"].items():
+            formbits.currency_input(label, key=f"cp_{DRAWER_KEY}_{field_key}")
+        submitted = st.form_submit_button(app_copy["navigation"]["continue"])
+
+    layout.render_drawer_summary(
+        app_copy["drawer_summary_label"],
+        drawer_copy["subtotal"],
+        drawer_copy["summary_hint"],
+    )
+
+    back_col, next_col = st.columns([1, 1])
+    with back_col:
+        st.button(app_copy["navigation"]["back"], key="cp_medical_back", on_click=nav.go_previous)
+    with next_col:
+        if submitted:
+            nav.mark_drawer_complete(DRAWER_KEY)
+            nav.go_next()
+        else:
+            st.write(" ")

--- a/ui/pages/cp/40_insurance_benefits.py
+++ b/ui/pages/cp/40_insurance_benefits.py
@@ -1,0 +1,47 @@
+"""Insurance & benefits drawer UI."""
+from __future__ import annotations
+
+import streamlit as st
+
+from senior_nav.components import formbits, layout
+from senior_nav.cost_planner import nav, state
+
+DRAWER_KEY = "insurance_benefits"
+
+
+def render() -> None:
+    copy = state.get_copy()
+    drawer_copy = copy["drawers"][DRAWER_KEY]
+    app_copy = copy["app"]
+    nav.mark_drawer_open(DRAWER_KEY)
+
+    st.markdown(f"### {drawer_copy['title']}")
+    st.caption(drawer_copy["caption"])
+
+    qualifiers = state.get_state()["qualifiers"]
+    hidden_fields = set()
+    if qualifiers.get("is_veteran") is False:
+        hidden_fields.add("va_benefits")
+
+    with st.form(f"cp_{DRAWER_KEY}_form"):
+        for field_key, label in drawer_copy["fields"].items():
+            if field_key in hidden_fields:
+                continue
+            formbits.currency_input(label, key=f"cp_{DRAWER_KEY}_{field_key}")
+        submitted = st.form_submit_button(app_copy["navigation"]["continue"])
+
+    layout.render_drawer_summary(
+        app_copy["drawer_summary_label"],
+        drawer_copy["subtotal"],
+        drawer_copy["summary_hint"],
+    )
+
+    back_col, next_col = st.columns([1, 1])
+    with back_col:
+        st.button(app_copy["navigation"]["back"], key="cp_insurance_back", on_click=nav.go_previous)
+    with next_col:
+        if submitted:
+            nav.mark_drawer_complete(DRAWER_KEY)
+            nav.go_next()
+        else:
+            st.write(" ")

--- a/ui/pages/cp/50_debts_other.py
+++ b/ui/pages/cp/50_debts_other.py
@@ -1,0 +1,40 @@
+"""Debts & other drawer UI."""
+from __future__ import annotations
+
+import streamlit as st
+
+from senior_nav.components import formbits, layout
+from senior_nav.cost_planner import nav, state
+
+DRAWER_KEY = "debts_other"
+
+
+def render() -> None:
+    copy = state.get_copy()
+    drawer_copy = copy["drawers"][DRAWER_KEY]
+    app_copy = copy["app"]
+    nav.mark_drawer_open(DRAWER_KEY)
+
+    st.markdown(f"### {drawer_copy['title']}")
+    st.caption(drawer_copy["caption"])
+
+    with st.form(f"cp_{DRAWER_KEY}_form"):
+        for field_key, label in drawer_copy["fields"].items():
+            formbits.currency_input(label, key=f"cp_{DRAWER_KEY}_{field_key}")
+        submitted = st.form_submit_button(app_copy["navigation"]["continue"])
+
+    layout.render_drawer_summary(
+        app_copy["drawer_summary_label"],
+        drawer_copy["subtotal"],
+        drawer_copy["summary_hint"],
+    )
+
+    back_col, next_col = st.columns([1, 1])
+    with back_col:
+        st.button(app_copy["navigation"]["back"], key="cp_debts_back", on_click=nav.go_previous)
+    with next_col:
+        if submitted:
+            nav.mark_drawer_complete(DRAWER_KEY)
+            nav.go_next()
+        else:
+            st.write(" ")

--- a/ui/pages/cp/60_review.py
+++ b/ui/pages/cp/60_review.py
@@ -1,0 +1,36 @@
+"""Review step."""
+from __future__ import annotations
+
+import streamlit as st
+
+from senior_nav.components import banners, layout
+from senior_nav.cost_planner import nav, state
+
+
+def render() -> None:
+    copy = state.get_copy()
+    review_copy = copy["review"]
+    app_copy = copy["app"]
+
+    st.markdown(f"### {review_copy['title']}")
+    st.write(review_copy["intro"])
+
+    for drawer_key, label in review_copy["accordion"].items():
+        drawer_copy = copy["drawers"][drawer_key]
+        with st.expander(label, expanded=drawer_key == "housing"):
+            st.write(drawer_copy["caption"])
+            layout.render_drawer_summary(
+                app_copy["drawer_summary_label"],
+                drawer_copy["subtotal"],
+                drawer_copy["summary_hint"],
+            )
+
+    st.markdown(f"#### {review_copy['suggestions_title']}")
+    for suggestion in review_copy["suggestions"]:
+        banners.render(suggestion["level"], suggestion["title"], suggestion["body"])
+
+    back_col, next_col = st.columns([1, 1])
+    with back_col:
+        st.button(app_copy["navigation"]["back"], key="cp_review_back", on_click=nav.go_previous)
+    with next_col:
+        st.button(app_copy["navigation"]["continue"], key="cp_review_continue", on_click=nav.go_next)

--- a/ui/pages/cp/70_summary.py
+++ b/ui/pages/cp/70_summary.py
@@ -1,0 +1,49 @@
+"""Summary step."""
+from __future__ import annotations
+
+import streamlit as st
+
+from senior_nav.cost_planner import nav, state
+
+
+def render() -> None:
+    copy = state.get_copy()
+    summary_copy = copy["summary"]
+    app_copy = copy["app"]
+    totals = app_copy["sidebar"]["totals_rows"]
+
+    st.markdown(f"### {summary_copy['title']}")
+    st.write(summary_copy["intro"])
+
+    rows_html = "".join(
+        f"<tr><td>{label}</td><td style='text-align:right;font-weight:600;'>{value}</td></tr>"
+        for label, value in totals
+    )
+    st.markdown(
+        f"""
+        <table style="width:100%; border-collapse:collapse; margin-bottom:1.5rem;">
+          <thead>
+            <tr style="text-align:left; border-bottom:1px solid var(--sn-color-border);">
+              <th>{summary_copy['table_headers'][0]}</th>
+              <th style="text-align:right;">{summary_copy['table_headers'][1]}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows_html}
+          </tbody>
+        </table>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    action_col1, action_col2 = st.columns(2)
+    with action_col1:
+        st.button(summary_copy["actions"]["download"], key="cp_summary_download", disabled=True)
+    with action_col2:
+        st.button(summary_copy["actions"]["share"], key="cp_summary_share", disabled=True)
+
+    back_col, next_col = st.columns([1, 1])
+    with back_col:
+        st.button(app_copy["navigation"]["back"], key="cp_summary_back", on_click=nav.go_previous)
+    with next_col:
+        st.button(app_copy["navigation"]["continue"], key="cp_summary_continue", on_click=nav.go_next)

--- a/ui/pages/cp/80_confirm.py
+++ b/ui/pages/cp/80_confirm.py
@@ -1,0 +1,29 @@
+"""Confirm step."""
+from __future__ import annotations
+
+import streamlit as st
+
+from senior_nav.components import formbits
+from senior_nav.cost_planner import nav, state
+
+
+def render() -> None:
+    copy = state.get_copy()
+    confirm_copy = copy["confirm"]
+    app_copy = copy["app"]
+
+    st.markdown(f"### {confirm_copy['title']}")
+    st.write(confirm_copy["intro"])
+
+    _ = formbits.checklist(confirm_copy["checklist"], key_prefix="cp_confirm_list")
+    ready = formbits.confirmation_checkbox(confirm_copy["confirm_label"], key="cp_confirm_ready")
+
+    action_col1, action_col2 = st.columns([1, 1])
+    with action_col1:
+        st.button(app_copy["navigation"]["back"], key="cp_confirm_back", on_click=nav.go_previous)
+    with action_col2:
+        if st.button(confirm_copy["share_button"], key="cp_confirm_share", disabled=not ready):
+            st.success(confirm_copy["share_note"])
+            st.balloons()
+
+    st.caption(confirm_copy["share_note"])


### PR DESCRIPTION
## Summary
- build the cost planner shell with shared copy, header chrome, and wizard routing across CP steps
- add detailed CP step pages with conditional fields plus review, summary, and confirm placeholders using shared components
- introduce Navi mock assistant styling and guardrails alongside design lint tests for copy and labels

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e142673b908323aeba9ebe58325b8c