### PR TITLE
Restyle Guided Care Plan flow with shared shell

### DIFF
--- a/senior_nav/components/gcp_shell.py
+++ b/senior_nav/components/gcp_shell.py
@@ -1,0 +1,46 @@
+import streamlit as st
+
+from senior_nav.components.theme import inject_theme
+from senior_nav.components.card import card_panel
+from senior_nav.components.stepper import render as render_stepper
+
+GCP_STEPS = [
+    ("Financial", "ui/pages/gcp.py"),
+    ("Daily Life & Support", "ui/pages/gcp_daily_life.py"),
+    ("Health & Safety", "ui/pages/gcp_health_safety.py"),
+    ("Context & Preferences", "ui/pages/gcp_context_prefs.py"),
+    ("Recommendation", "ui/pages/gcp_recommendation.py"),
+]
+
+
+def centered_container():
+    return st.columns([1, 2, 1])[1]
+
+
+def gcp_header(current_index: int):
+    inject_theme()
+    st.markdown("")
+    titles = [label for label, _ in GCP_STEPS]
+    render_stepper(titles, current_index)
+
+
+def gcp_section(title: str, subtitle: str, body_render_fn):
+    with centered_container():
+        card_panel(title=title, subtitle=subtitle, body=body_render_fn)
+
+
+def primary_secondary(
+    primary_label: str,
+    on_primary,
+    secondary_label: str | None = None,
+    on_secondary=None,
+    disabled: bool = False,
+):
+    cols = st.columns([1, 1])
+    with cols[0]:
+        if st.button(primary_label, type="primary", use_container_width=True, disabled=disabled):
+            on_primary()
+    if secondary_label and on_secondary:
+        with cols[1]:
+            if st.button(secondary_label, use_container_width=True):
+                on_secondary()

--- a/ui/pages/gcp.py
+++ b/ui/pages/gcp.py
@@ -1,12 +1,62 @@
-"""Placeholder for the Guided Care Plan page."""
-from __future__ import annotations
-
 import streamlit as st
+from senior_nav.components.nav import safe_switch_page
+from senior_nav.components.gcp_shell import (
+    gcp_header,
+    gcp_section,
+    primary_secondary,
+)
 
-from senior_nav.components.theme import inject_theme
 
-st.set_page_config(layout="wide")
-inject_theme()
+def _init_state():
+    st.session_state.setdefault("gcp_answers", {})
+    st.session_state.setdefault("gcp_status", "in_progress")
 
-st.title("Guided Care Plan")
-st.info("Detailed UI will ship in a later wiring milestone.")
+
+def main():
+    _init_state()
+    gcp_header(0)
+
+    answers = st.session_state["gcp_answers"]
+
+    def form():
+        st.subheader("Financial Eligibility")
+        answers["medicaid_status"] = st.radio(
+            "Are you currently on Medicaid or receiving state long-term care assistance?",
+            options=["yes", "no", "unsure"],
+            index=(
+                ["yes", "no", "unsure"].index(answers.get("medicaid_status", "no"))
+                if answers.get("medicaid_status") in ["yes", "no", "unsure"]
+                else 1
+            ),
+            horizontal=True,
+        )
+
+        if answers["medicaid_status"] != "yes":
+            st.subheader("Financial Confidence")
+            answers["funding_confidence"] = st.radio(
+                "How confident do you feel about paying for care?",
+                options=["no_worries", "confident", "unsure", "not_confident"],
+                index=(
+                    ["no_worries", "confident", "unsure", "not_confident"].index(
+                        answers.get("funding_confidence", "unsure")
+                    )
+                ),
+                horizontal=True,
+            )
+        else:
+            st.info(
+                "Medicaid changes how care is paid. We’ll still show a care recommendation, then guide the next step."
+            )
+
+        st.session_state["gcp_answers"] = answers
+
+        def _next():
+            safe_switch_page("ui/pages/gcp_daily_life.py")
+
+        primary_secondary("Continue", _next)
+
+    gcp_section("Guided Care Plan", "Financial", form)
+
+
+if __name__ == "__main__":
+    main()

--- a/ui/pages/gcp_context_prefs.py
+++ b/ui/pages/gcp_context_prefs.py
@@ -1,12 +1,50 @@
-"""Placeholder for the Guided Care Plan Context & Preferences section."""
-from __future__ import annotations
-
 import streamlit as st
+from senior_nav.components.nav import safe_switch_page
+from senior_nav.components.gcp_shell import gcp_header, gcp_section, primary_secondary
 
-from senior_nav.components.theme import inject_theme
 
-st.set_page_config(layout="wide")
-inject_theme()
+def _init_state():
+    st.session_state.setdefault("gcp_answers", {})
 
-st.title("Guided Care Plan · Context & Preferences")
-st.info("Section UI will arrive with the Guided Care Plan wiring work.")
+
+def _normalize_none(selected_list):
+    if "none" in selected_list and len(selected_list) > 1:
+        return []
+    return selected_list
+
+
+def main():
+    _init_state()
+    gcp_header(3)
+    answers = st.session_state["gcp_answers"]
+
+    def form():
+        chronic = st.multiselect(
+            "Any chronic conditions?",
+            ["diabetes", "parkinson", "stroke", "copd", "chf", "other", "none"],
+            default=answers.get("chronic", []),
+        )
+        answers["chronic"] = _normalize_none(chronic)
+
+        preferences = st.multiselect(
+            "Any strong preferences?",
+            ["stay_home", "be_near_family", "structured_care", "private_room", "none"],
+            default=answers.get("preferences", []),
+        )
+        answers["preferences"] = _normalize_none(preferences)
+
+        st.session_state["gcp_answers"] = answers
+
+        def _back():
+            safe_switch_page("ui/pages/gcp_health_safety.py")
+
+        def _next():
+            safe_switch_page("ui/pages/gcp_recommendation.py")
+
+        primary_secondary("Continue", _next, "Back", _back)
+
+    gcp_section("Guided Care Plan", "Context & Preferences", form)
+
+
+if __name__ == "__main__":
+    main()

--- a/ui/pages/gcp_daily_life.py
+++ b/ui/pages/gcp_daily_life.py
@@ -1,12 +1,69 @@
-"""Placeholder for the Guided Care Plan Daily Life section."""
-from __future__ import annotations
-
 import streamlit as st
+from senior_nav.components.nav import safe_switch_page
+from senior_nav.components.gcp_shell import gcp_header, gcp_section, primary_secondary
 
-from senior_nav.components.theme import inject_theme
 
-st.set_page_config(layout="wide")
-inject_theme()
+def _init_state():
+    st.session_state.setdefault("gcp_answers", {})
 
-st.title("Guided Care Plan · Daily Life")
-st.info("Section UI will arrive with the Guided Care Plan wiring work.")
+
+def main():
+    _init_state()
+    gcp_header(1)
+    answers = st.session_state["gcp_answers"]
+
+    def form():
+        answers["who_for"] = st.radio(
+            "Who are you planning for?",
+            ["self", "parent", "spouse", "other"],
+            index=(
+                ["self", "parent", "spouse", "other"].index(
+                    answers.get("who_for", "self")
+                )
+            ),
+            horizontal=True,
+        )
+        answers["living_now"] = st.radio(
+            "Where do they live today?",
+            ["own_home", "with_family", "independent", "assisted", "memory", "skilled"],
+            index=(
+                ["own_home", "with_family", "independent", "assisted", "memory", "skilled"].index(
+                    answers.get("living_now", "own_home")
+                )
+            ),
+            horizontal=True,
+        )
+        answers["caregiver_support"] = st.radio(
+            "How much caregiver support is available?",
+            ["none", "few_days_week", "most_days", "24_7"],
+            index=(
+                ["none", "few_days_week", "most_days", "24_7"].index(
+                    answers.get("caregiver_support", "none")
+                )
+            ),
+            horizontal=True,
+        )
+        answers["adl_help"] = st.radio(
+            "How many daily activities need help?",
+            ["0-1", "2-3", "4-5", "6+"],
+            index=(
+                ["0-1", "2-3", "4-5", "6+"].index(answers.get("adl_help", "0-1"))
+            ),
+            horizontal=True,
+        )
+
+        st.session_state["gcp_answers"] = answers
+
+        def _back():
+            safe_switch_page("ui/pages/gcp.py")
+
+        def _next():
+            safe_switch_page("ui/pages/gcp_health_safety.py")
+
+        primary_secondary("Continue", _next, "Back", _back)
+
+    gcp_section("Guided Care Plan", "Daily Life & Support", form)
+
+
+if __name__ == "__main__":
+    main()

--- a/ui/pages/gcp_health_safety.py
+++ b/ui/pages/gcp_health_safety.py
@@ -1,12 +1,96 @@
-"""Placeholder for the Guided Care Plan Health & Safety section."""
-from __future__ import annotations
-
 import streamlit as st
+from senior_nav.components.nav import safe_switch_page
+from senior_nav.components.gcp_shell import gcp_header, gcp_section, primary_secondary
 
-from senior_nav.components.theme import inject_theme
 
-st.set_page_config(layout="wide")
-inject_theme()
+def _init_state():
+    st.session_state.setdefault("gcp_answers", {})
 
-st.title("Guided Care Plan · Health & Safety")
-st.info("Section UI will arrive with the Guided Care Plan wiring work.")
+
+def _normalize_none(selected_list):
+    if "none" in selected_list and len(selected_list) > 1:
+        return []
+    return selected_list
+
+
+def main():
+    _init_state()
+    gcp_header(2)
+    answers = st.session_state["gcp_answers"]
+
+    def form():
+        answers["cognition"] = st.radio(
+            "How is memory and thinking?",
+            ["normal", "mild", "moderate", "severe"],
+            index=(
+                ["normal", "mild", "moderate", "severe"].index(
+                    answers.get("cognition", "normal")
+                )
+            ),
+            horizontal=True,
+        )
+
+        behavior = st.multiselect(
+            "Any wandering or unsafe behaviors?",
+            ["wandering", "agitation", "exit_seeking", "none"],
+            default=answers.get("behavior_risks", []),
+        )
+        answers["behavior_risks"] = _normalize_none(behavior)
+
+        answers["falls"] = st.radio(
+            "Falls in the last 12 months?",
+            ["none", "one", "recurrent"],
+            index=(
+                ["none", "one", "recurrent"].index(answers.get("falls", "none"))
+            ),
+            horizontal=True,
+        )
+
+        answers["med_mgmt"] = st.radio(
+            "How complex are medications to manage?",
+            ["simple", "several", "complex"],
+            index=(
+                ["simple", "several", "complex"].index(
+                    answers.get("med_mgmt", "simple")
+                )
+            ),
+            horizontal=True,
+        )
+
+        answers["home_safety"] = st.radio(
+            "Is the home setup safe (stairs/bath/etc.)?",
+            ["safe", "some_risks", "unsafe"],
+            index=(
+                ["safe", "some_risks", "unsafe"].index(
+                    answers.get("home_safety", "safe")
+                )
+            ),
+            horizontal=True,
+        )
+
+        answers["supervision"] = st.radio(
+            "Do they have needed supervision at home?",
+            ["always", "sometimes", "rarely", "never"],
+            index=(
+                ["always", "sometimes", "rarely", "never"].index(
+                    answers.get("supervision", "always")
+                )
+            ),
+            horizontal=True,
+        )
+
+        st.session_state["gcp_answers"] = answers
+
+        def _back():
+            safe_switch_page("ui/pages/gcp_daily_life.py")
+
+        def _next():
+            safe_switch_page("ui/pages/gcp_context_prefs.py")
+
+        primary_secondary("Continue", _next, "Back", _back)
+
+    gcp_section("Guided Care Plan", "Health & Safety", form)
+
+
+if __name__ == "__main__":
+    main()

--- a/ui/pages/gcp_recommendation.py
+++ b/ui/pages/gcp_recommendation.py
@@ -1,12 +1,59 @@
-"""Placeholder for the Guided Care Plan recommendation page."""
-from __future__ import annotations
-
 import streamlit as st
+from senior_nav.components.nav import safe_switch_page
+from senior_nav.components.gcp_shell import gcp_header, gcp_section, primary_secondary
 
-from senior_nav.components.theme import inject_theme
 
-st.set_page_config(layout="wide")
-inject_theme()
+def _init_state():
+    st.session_state.setdefault("gcp_answers", {})
+    st.session_state.setdefault("gcp", {})
 
-st.title("Care Plan Recommendation")
-st.info("Recommendation UI will be added after navigation wiring is complete.")
+
+def main():
+    _init_state()
+    gcp_header(4)
+    answers = st.session_state["gcp_answers"]
+    gcp = st.session_state.get("gcp", {})
+
+    def rec_body():
+        payment_context = gcp.get("payment_context") or (
+            "medicaid" if answers.get("medicaid_status") == "yes" else "private"
+        )
+        st.subheader("Your care recommendation")
+        st.write(
+            "We’ll show your personalized recommendation here with a short explanation."
+        )
+        if payment_context == "medicaid":
+            st.info(
+                """Medicaid covers long-term care differently. Next we’ll guide you to Plan for My Advisor. Cost Planner is optional."""
+            )
+        else:
+            st.info(
+                """You can continue to the Cost Planner to explore costs, offsets, and timeline."""
+            )
+
+        def _to_cp():
+            safe_switch_page("ui/pages/03_cost_planner.py")
+
+        def _to_pfma():
+            safe_switch_page("ui/pages/05_plan_for_my_advisor.py")
+
+        if payment_context == "medicaid":
+            primary_secondary(
+                "Continue to Plan for My Advisor",
+                _to_pfma,
+                "Open Cost Planner (optional)",
+                _to_cp,
+            )
+        else:
+            primary_secondary(
+                "Open Cost Planner",
+                _to_cp,
+                "Plan for My Advisor",
+                _to_pfma,
+            )
+
+    gcp_section("Guided Care Plan", "Recommendation", rec_body)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a reusable Guided Care Plan shell component with shared stepper and centered card layout
- update each Guided Care Plan page to use the new shell and contextual sections with consistent controls
- polish the recommendation page to surface Medicaid/private banners and aligned CTAs

## Testing
- python -m compileall senior_nav/components/gcp_shell.py ui/pages/gcp.py ui/pages/gcp_daily_life.py ui/pages/gcp_health_safety.py ui/pages/gcp_context_prefs.py ui/pages/gcp_recommendation.py

------
https://chatgpt.com/codex/tasks/task_b_68e16175e0f883238ac19b55f3e0c086