### PR TITLE
feat: style GCP chips like primary nav

### DIFF
--- a/senior_nav/components/__init__.py
+++ b/senior_nav/components/__init__.py
@@ -1,11 +1,12 @@
 """Convenience exports for shared UI components."""
 from __future__ import annotations
 
-from . import banners, card, formbits, layout, nav, stepper, theme
+from . import banners, card, choice_chips, formbits, layout, nav, stepper, theme
 
 __all__ = [
     "banners",
     "card",
+    "choice_chips",
     "formbits",
     "layout",
     "nav",

--- a/senior_nav/components/choice_chips.py
+++ b/senior_nav/components/choice_chips.py
@@ -1,0 +1,100 @@
+"""Reusable Streamlit choice chip components for the Senior Navigator."""
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+import streamlit as st
+
+
+def _ensure_sequence(options: Iterable[str]) -> list[str]:
+    """Return a concrete list copy of the provided options."""
+    return list(options)
+
+
+def choice_single(
+    label: str,
+    options: Sequence[str],
+    value: str | None = None,
+    *,
+    key: str | None = None,
+) -> str:
+    """Render an accessible single-select control styled as a chip group.
+
+    Prefers Streamlit's segmented control (>= 1.30) for built-in keyboard support.
+    Falls back to ``st.radio`` while preserving horizontal presentation.
+    Returns the selected option.
+    """
+
+    opts = _ensure_sequence(options)
+    if not opts:
+        raise ValueError("choice_single requires at least one option")
+
+    selection = value if value in opts else opts[0]
+    widget_key = key or f"cs_{label}"
+
+    try:
+        selected = st.segmented_control(
+            label,
+            opts,
+            default=selection,
+            key=widget_key,
+        )
+    except Exception:
+        selected = st.radio(
+            label,
+            opts,
+            index=opts.index(selection),
+            horizontal=True,
+            key=widget_key,
+        )
+    return selected
+
+
+def choice_multi(
+    label: str,
+    options: Sequence[str],
+    values: Iterable[str] | None = None,
+    *,
+    key: str | None = None,
+) -> list[str]:
+    """Render an accessible multi-select control styled as a chip grid.
+
+    Uses native checkboxes for screen-reader compatibility and applies chip
+    styling via CSS. Returns the list of selected options ordered as provided.
+    """
+
+    opts = _ensure_sequence(options)
+    current_values = set(values or [])
+    widget_prefix = key or f"cm_{label}"
+
+    if not opts:
+        return []
+
+    column_count = min(len(opts), 4)
+    columns = st.columns(column_count)
+
+    selected: list[str] = []
+    for index, option in enumerate(opts):
+        column = columns[index % column_count]
+        with column:
+            checked = st.checkbox(
+                option,
+                value=option in current_values,
+                key=f"{widget_prefix}_{option}",
+            )
+        if checked:
+            selected.append(option)
+
+    return selected
+
+
+def normalize_none(values: Iterable[str] | None) -> list[str]:
+    """Apply the shared "none" selection rule used across GCP multi-selects."""
+
+    if not values:
+        return []
+
+    collected = list(values)
+    if "none" in collected and len(collected) > 1:
+        return []
+    return collected

--- a/senior_nav/components/theme.py
+++ b/senior_nav/components/theme.py
@@ -1,11 +1,15 @@
 """Theme helpers for the Senior Care Navigator UI shell."""
 from __future__ import annotations
 
+from pathlib import Path
 from textwrap import dedent
 
 import streamlit as st
 
 from senior_nav.ui_style import tokens
+
+_STATIC_DIR = Path(__file__).resolve().parent.parent / "static"
+_CHIP_CSS_PATH = _STATIC_DIR / "chips.css"
 
 _THEME_STATE_KEY = "__sn_theme_injected__"
 
@@ -164,4 +168,7 @@ def inject_theme() -> None:
         return
 
     st.markdown(_build_css(), unsafe_allow_html=True)
+    if _CHIP_CSS_PATH.exists():
+        chips_css = _CHIP_CSS_PATH.read_text(encoding="utf-8")
+        st.markdown(f"<style>{chips_css}</style>", unsafe_allow_html=True)
     st.session_state[_THEME_STATE_KEY] = True

--- a/senior_nav/static/chips.css
+++ b/senior_nav/static/chips.css
@@ -1,0 +1,85 @@
+/* Choice chip styling shared across GCP pages. */
+
+:root {
+  --chip-font: 16px;
+  --chip-pad-y: 12px;
+  --chip-pad-x: 16px;
+  --chip-radius: 999px;
+  --chip-gap: 12px;
+}
+
+[data-testid="stSegmentedControl"] > div > label {
+  font-size: var(--chip-font);
+  padding: var(--chip-pad-y) var(--chip-pad-x);
+  border-radius: var(--chip-radius);
+  border: 1px solid var(--secondary-300, #d7dbe0);
+  background: var(--surface, #f7f9fc);
+  color: var(--ink-900, #111827);
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.02);
+  min-height: 44px;
+  font-weight: 600;
+}
+
+[data-testid="stSegmentedControl"] > div > label:hover {
+  background: var(--surface-hover, #eef2f7);
+}
+
+[data-testid="stSegmentedControl"] > div > input:checked + label {
+  background: var(--brand-600, #2f49d1);
+  color: #fff;
+  border-color: var(--brand-600, #2f49d1);
+  box-shadow: 0 0 0 2px rgba(47, 73, 209, 0.15);
+}
+
+[data-testid="stSegmentedControl"] > div > input:focus-visible + label {
+  outline: 3px solid var(--brand-300, #bfd0ff);
+  outline-offset: 2px;
+}
+
+.stCheckbox > label {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-size: var(--chip-font);
+  font-weight: 600;
+  padding: var(--chip-pad-y) var(--chip-pad-x);
+  margin: 6px var(--chip-gap) 6px 0;
+  border-radius: var(--chip-radius);
+  border: 1px solid var(--secondary-300, #d7dbe0);
+  background: var(--surface, #f7f9fc);
+  color: var(--ink-900, #111827);
+  min-height: 44px;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.stCheckbox > label:hover {
+  background: var(--surface-hover, #eef2f7);
+}
+
+.stCheckbox input:checked + div + label,
+.stCheckbox input:checked + label {
+  background: var(--brand-50, #e8eeff);
+  border-color: var(--brand-500, #5267f6);
+  color: var(--ink-900, #111827);
+  box-shadow: inset 0 0 0 1px var(--brand-500, #5267f6);
+}
+
+.skn-chip--dark {
+  background: #0f172a;
+  color: #fff;
+  border-color: #0f172a;
+}
+
+.skn-chip--dark:hover {
+  background: #111827;
+}
+
+.skn-question h3,
+.skn-question h4 {
+  margin-bottom: 8px !important;
+}
+
+.skn-question + .skn-question {
+  margin-top: 18px !important;
+}

--- a/ui/pages/gcp.py
+++ b/ui/pages/gcp.py
@@ -1,4 +1,5 @@
 import streamlit as st
+from senior_nav.components.choice_chips import choice_single
 from senior_nav.components.nav import safe_switch_page
 from senior_nav.components.gcp_shell import (
     gcp_header,
@@ -20,28 +21,20 @@ def main():
 
     def form():
         st.subheader("Financial Eligibility")
-        answers["medicaid_status"] = st.radio(
+        answers["medicaid_status"] = choice_single(
             "Are you currently on Medicaid or receiving state long-term care assistance?",
-            options=["yes", "no", "unsure"],
-            index=(
-                ["yes", "no", "unsure"].index(answers.get("medicaid_status", "no"))
-                if answers.get("medicaid_status") in ["yes", "no", "unsure"]
-                else 1
-            ),
-            horizontal=True,
+            ["yes", "no", "unsure"],
+            value=answers.get("medicaid_status", "no"),
+            key="gcp_medicaid_status",
         )
 
         if answers["medicaid_status"] != "yes":
             st.subheader("Financial Confidence")
-            answers["funding_confidence"] = st.radio(
+            answers["funding_confidence"] = choice_single(
                 "How confident do you feel about paying for care?",
-                options=["no_worries", "confident", "unsure", "not_confident"],
-                index=(
-                    ["no_worries", "confident", "unsure", "not_confident"].index(
-                        answers.get("funding_confidence", "unsure")
-                    )
-                ),
-                horizontal=True,
+                ["no_worries", "confident", "unsure", "not_confident"],
+                value=answers.get("funding_confidence", "unsure"),
+                key="gcp_funding_confidence",
             )
         else:
             st.info(

--- a/ui/pages/gcp_context_prefs.py
+++ b/ui/pages/gcp_context_prefs.py
@@ -1,37 +1,34 @@
 import streamlit as st
+from senior_nav.components.choice_chips import choice_multi, normalize_none
 from senior_nav.components.nav import safe_switch_page
 from senior_nav.components.gcp_shell import gcp_header, gcp_section, primary_secondary
 
 
 def _init_state():
     st.session_state.setdefault("gcp_answers", {})
-
-
-def _normalize_none(selected_list):
-    if "none" in selected_list and len(selected_list) > 1:
-        return []
-    return selected_list
-
-
 def main():
     _init_state()
     gcp_header(3)
     answers = st.session_state["gcp_answers"]
 
     def form():
-        chronic = st.multiselect(
-            "Any chronic conditions?",
-            ["diabetes", "parkinson", "stroke", "copd", "chf", "other", "none"],
-            default=answers.get("chronic", []),
+        answers["chronic"] = normalize_none(
+            choice_multi(
+                "Any chronic conditions?",
+                ["diabetes", "parkinson", "stroke", "copd", "chf", "other", "none"],
+                values=answers.get("chronic", []),
+                key="gcp_chronic",
+            )
         )
-        answers["chronic"] = _normalize_none(chronic)
 
-        preferences = st.multiselect(
-            "Any strong preferences?",
-            ["stay_home", "be_near_family", "structured_care", "private_room", "none"],
-            default=answers.get("preferences", []),
+        answers["preferences"] = normalize_none(
+            choice_multi(
+                "Any strong preferences?",
+                ["stay_home", "be_near_family", "structured_care", "private_room", "none"],
+                values=answers.get("preferences", []),
+                key="gcp_preferences",
+            )
         )
-        answers["preferences"] = _normalize_none(preferences)
 
         st.session_state["gcp_answers"] = answers
 

--- a/ui/pages/gcp_daily_life.py
+++ b/ui/pages/gcp_daily_life.py
@@ -1,4 +1,5 @@
 import streamlit as st
+from senior_nav.components.choice_chips import choice_single
 from senior_nav.components.nav import safe_switch_page
 from senior_nav.components.gcp_shell import gcp_header, gcp_section, primary_secondary
 
@@ -13,43 +14,29 @@ def main():
     answers = st.session_state["gcp_answers"]
 
     def form():
-        answers["who_for"] = st.radio(
+        answers["who_for"] = choice_single(
             "Who are you planning for?",
             ["self", "parent", "spouse", "other"],
-            index=(
-                ["self", "parent", "spouse", "other"].index(
-                    answers.get("who_for", "self")
-                )
-            ),
-            horizontal=True,
+            value=answers.get("who_for", "self"),
+            key="gcp_who_for",
         )
-        answers["living_now"] = st.radio(
+        answers["living_now"] = choice_single(
             "Where do they live today?",
             ["own_home", "with_family", "independent", "assisted", "memory", "skilled"],
-            index=(
-                ["own_home", "with_family", "independent", "assisted", "memory", "skilled"].index(
-                    answers.get("living_now", "own_home")
-                )
-            ),
-            horizontal=True,
+            value=answers.get("living_now", "own_home"),
+            key="gcp_living_now",
         )
-        answers["caregiver_support"] = st.radio(
+        answers["caregiver_support"] = choice_single(
             "How much caregiver support is available?",
             ["none", "few_days_week", "most_days", "24_7"],
-            index=(
-                ["none", "few_days_week", "most_days", "24_7"].index(
-                    answers.get("caregiver_support", "none")
-                )
-            ),
-            horizontal=True,
+            value=answers.get("caregiver_support", "none"),
+            key="gcp_caregiver_support",
         )
-        answers["adl_help"] = st.radio(
+        answers["adl_help"] = choice_single(
             "How many daily activities need help?",
             ["0-1", "2-3", "4-5", "6+"],
-            index=(
-                ["0-1", "2-3", "4-5", "6+"].index(answers.get("adl_help", "0-1"))
-            ),
-            horizontal=True,
+            value=answers.get("adl_help", "0-1"),
+            key="gcp_adl_help",
         )
 
         st.session_state["gcp_answers"] = answers

--- a/ui/pages/gcp_health_safety.py
+++ b/ui/pages/gcp_health_safety.py
@@ -1,82 +1,63 @@
 import streamlit as st
+from senior_nav.components.choice_chips import (
+    choice_multi,
+    choice_single,
+    normalize_none,
+)
 from senior_nav.components.nav import safe_switch_page
 from senior_nav.components.gcp_shell import gcp_header, gcp_section, primary_secondary
 
 
 def _init_state():
     st.session_state.setdefault("gcp_answers", {})
-
-
-def _normalize_none(selected_list):
-    if "none" in selected_list and len(selected_list) > 1:
-        return []
-    return selected_list
-
-
 def main():
     _init_state()
     gcp_header(2)
     answers = st.session_state["gcp_answers"]
 
     def form():
-        answers["cognition"] = st.radio(
+        answers["cognition"] = choice_single(
             "How is memory and thinking?",
             ["normal", "mild", "moderate", "severe"],
-            index=(
-                ["normal", "mild", "moderate", "severe"].index(
-                    answers.get("cognition", "normal")
-                )
-            ),
-            horizontal=True,
+            value=answers.get("cognition", "normal"),
+            key="gcp_cognition",
         )
 
-        behavior = st.multiselect(
-            "Any wandering or unsafe behaviors?",
-            ["wandering", "agitation", "exit_seeking", "none"],
-            default=answers.get("behavior_risks", []),
+        answers["behavior_risks"] = normalize_none(
+            choice_multi(
+                "Any wandering or unsafe behaviors?",
+                ["wandering", "agitation", "exit_seeking", "none"],
+                values=answers.get("behavior_risks", []),
+                key="gcp_behavior_risks",
+            )
         )
-        answers["behavior_risks"] = _normalize_none(behavior)
 
-        answers["falls"] = st.radio(
+        answers["falls"] = choice_single(
             "Falls in the last 12 months?",
             ["none", "one", "recurrent"],
-            index=(
-                ["none", "one", "recurrent"].index(answers.get("falls", "none"))
-            ),
-            horizontal=True,
+            value=answers.get("falls", "none"),
+            key="gcp_falls",
         )
 
-        answers["med_mgmt"] = st.radio(
+        answers["med_mgmt"] = choice_single(
             "How complex are medications to manage?",
             ["simple", "several", "complex"],
-            index=(
-                ["simple", "several", "complex"].index(
-                    answers.get("med_mgmt", "simple")
-                )
-            ),
-            horizontal=True,
+            value=answers.get("med_mgmt", "simple"),
+            key="gcp_med_mgmt",
         )
 
-        answers["home_safety"] = st.radio(
+        answers["home_safety"] = choice_single(
             "Is the home setup safe (stairs/bath/etc.)?",
             ["safe", "some_risks", "unsafe"],
-            index=(
-                ["safe", "some_risks", "unsafe"].index(
-                    answers.get("home_safety", "safe")
-                )
-            ),
-            horizontal=True,
+            value=answers.get("home_safety", "safe"),
+            key="gcp_home_safety",
         )
 
-        answers["supervision"] = st.radio(
+        answers["supervision"] = choice_single(
             "Do they have needed supervision at home?",
             ["always", "sometimes", "rarely", "never"],
-            index=(
-                ["always", "sometimes", "rarely", "never"].index(
-                    answers.get("supervision", "always")
-                )
-            ),
-            horizontal=True,
+            value=answers.get("supervision", "always"),
+            key="gcp_supervision",
         )
 
         st.session_state["gcp_answers"] = answers


### PR DESCRIPTION
## Summary
- add reusable choice chip components to provide consistent styling across GCP flows
- load dedicated chip CSS through the shared theme so buttons match the primary navigation look
- replace radios and multiselects in the GCP pages with the new components while preserving existing answer handling

## Testing
- python -m compileall senior_nav/components/choice_chips.py ui/pages/gcp.py ui/pages/gcp_daily_life.py ui/pages/gcp_health_safety.py ui/pages/gcp_context_prefs.py

------
https://chatgpt.com/codex/tasks/task_b_68e1666693dc832393e6a20a832c8197