### PR TITLE
Ensure consistent themed button styling

### DIFF
--- a/senior_nav/components/buttons.py
+++ b/senior_nav/components/buttons.py
@@ -1,62 +1,40 @@
 """Scoped button helpers for consistent styling across pages."""
 from __future__ import annotations
 
-from contextlib import contextmanager
-from pathlib import Path
-
 import streamlit as st
 
-from senior_nav.components import theme
-
-_SCOPE_CLASS = "skn-scope"
-_CSS_STATE_KEY = "__sn_buttons_css__"
+_SCOPE_KEY = "__sn_buttons_scope_stack__"
 
 
-def _load_css() -> str:
-    css_path = Path(__file__).resolve().parent.parent / "static" / "buttons.css"
-    try:
-        return css_path.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        return ""
+def page_start():
+    stack = st.session_state.setdefault(_SCOPE_KEY, 0)
+    st.session_state[_SCOPE_KEY] = stack + 1
+    st.markdown('<div class="sn-scope">', unsafe_allow_html=True)
 
 
-def _ensure_css() -> None:
-    if st.session_state.get(_CSS_STATE_KEY):
-        return
-    css = _load_css()
-    if css:
-        st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
-    st.session_state[_CSS_STATE_KEY] = True
+def page_end():
+    stack = st.session_state.get(_SCOPE_KEY, 0)
+    if stack > 0:
+        st.markdown('</div>', unsafe_allow_html=True)
+        st.session_state[_SCOPE_KEY] = stack - 1
 
 
-@contextmanager
-def variant(variant_name: str):
-    st.markdown(f'<div data-variant="{variant_name}">', unsafe_allow_html=True)
-    try:
-        yield
-    finally:
-        st.markdown("</div>", unsafe_allow_html=True)
+def primary(label: str, key: str | None = None) -> bool:
+    st.markdown('<div data-variant="primary">', unsafe_allow_html=True)
+    clicked = st.button(label, key=key)
+    st.markdown('</div>', unsafe_allow_html=True)
+    return clicked
 
 
-def page_start() -> None:
-    """Begin a scoped button region."""
-    theme.inject_theme()
-    _ensure_css()
-    st.markdown(f'<div class="{_SCOPE_CLASS}">', unsafe_allow_html=True)
+def secondary(label: str, key: str | None = None) -> bool:
+    st.markdown('<div data-variant="secondary">', unsafe_allow_html=True)
+    clicked = st.button(label, key=key)
+    st.markdown('</div>', unsafe_allow_html=True)
+    return clicked
 
 
-def page_end() -> None:
-    """Close the scoped region."""
-    st.markdown("</div>", unsafe_allow_html=True)
-
-
-def primary(label: str, *, key: str | None = None, **kwargs) -> bool:
-    kwargs.setdefault("type", "primary")
-    kwargs.setdefault("use_container_width", True)
-    with variant("primary"):
-        return st.button(label, key=key, **kwargs)
-
-
-def secondary(label: str, *, key: str | None = None, **kwargs) -> bool:
-    kwargs.setdefault("use_container_width", True)
-    return st.button(label, key=key, **kwargs)
+def link(label: str, key: str | None = None) -> bool:
+    st.markdown('<div data-variant="link">', unsafe_allow_html=True)
+    clicked = st.button(label, key=key)
+    st.markdown('</div>', unsafe_allow_html=True)
+    return clicked

--- a/senior_nav/components/theme.py
+++ b/senior_nav/components/theme.py
@@ -9,11 +9,10 @@ import streamlit as st
 from senior_nav.ui_style import tokens
 
 _STATIC_DIR = Path(__file__).resolve().parent.parent / "static"
+_BUTTONS_CSS_PATH = _STATIC_DIR / "buttons.css"
 _CHIP_CSS_PATH = _STATIC_DIR / "chips.css"
 
 _THEME_STATE_KEY = "__sn_theme_injected__"
-_BUTTONS_STATE_KEY = "__sn_buttons_css__"
-_BUTTONS_CSS_CACHE: str | None = None
 
 
 def _build_css() -> str:
@@ -25,149 +24,135 @@ def _build_css() -> str:
     return dedent(
         f"""
         <style>
-        :root {{
-          --sn-color-primary: {palette['primary']};
-          --sn-color-ink: {palette['ink']};
-          --sn-color-bg: {palette['bg']};
-          --sn-color-bg-subtle: {palette['bgSubtle']};
-          --sn-color-border: {palette['border']};
-          --sn-color-info-bg: {palette['infoBG']};
-          --sn-color-warn-bg: {palette['warnBG']};
-          --sn-color-success-bg: {palette['successBG']};
-          --sn-radius-sm: {radius['sm']}px;
-          --sn-radius-md: {radius['md']}px;
-          --sn-radius-lg: {radius['lg']}px;
-          --sn-spacing-xs: {spacing['xs']}px;
-          --sn-spacing-sm: {spacing['sm']}px;
-          --sn-spacing-md: {spacing['md']}px;
-          --sn-spacing-lg: {spacing['lg']}px;
-          --sn-spacing-xl: {spacing['xl']}px;
-          --sn-spacing-xxl: {spacing['xxl']}px;
-          --sn-type-h1-size: {type_scale['h1']['size']}px;
-          --sn-type-h2-size: {type_scale['h2']['size']}px;
-          --sn-type-body-size: {type_scale['body']['size']}px;
-          --sn-type-small-size: {type_scale['small']['size']}px;
-          --sn-type-h1-weight: {type_scale['h1']['weight']};
-          --sn-type-h2-weight: {type_scale['h2']['weight']};
-          --sn-type-body-weight: {type_scale['body']['weight']};
-          --sn-type-small-weight: {type_scale['small']['weight']};
-          --sn-shadow-soft: 0 18px 38px rgba(17, 20, 24, 0.08);
-        }}
+          :root {{
+            --sn-color-primary: {palette['primary']};
+            --sn-color-ink: {palette['ink']};
+            --sn-color-bg: {palette['bg']};
+            --sn-color-bg-subtle: {palette['bgSubtle']};
+            --sn-color-border: {palette['border']};
+            --sn-color-info-bg: {palette['infoBG']};
+            --sn-color-warn-bg: {palette['warnBG']};
+            --sn-color-success-bg: {palette['successBG']};
+            --sn-radius-sm: {radius['sm']}px;
+            --sn-radius-md: {radius['md']}px;
+            --sn-radius-lg: {radius['lg']}px;
+            --sn-spacing-xs: {spacing['xs']}px;
+            --sn-spacing-sm: {spacing['sm']}px;
+            --sn-spacing-md: {spacing['md']}px;
+            --sn-spacing-lg: {spacing['lg']}px;
+            --sn-spacing-xl: {spacing['xl']}px;
+            --sn-spacing-xxl: {spacing['xxl']}px;
+            --sn-type-h1-size: {type_scale['h1']['size']}px;
+            --sn-type-h2-size: {type_scale['h2']['size']}px;
+            --sn-type-body-size: {type_scale['body']['size']}px;
+            --sn-type-small-size: {type_scale['small']['size']}px;
+            --sn-type-h1-weight: {type_scale['h1']['weight']};
+            --sn-type-h2-weight: {type_scale['h2']['weight']};
+            --sn-type-body-weight: {type_scale['body']['weight']};
+            --sn-type-small-weight: {type_scale['small']['weight']};
+            --sn-shadow-soft: 0 18px 38px rgba(17, 20, 24, 0.08);
+          }}
 
-        .sn-surface {{
-          background: var(--sn-color-bg);
-          color: var(--sn-color-ink);
-        }}
+          .sn-surface {{
+            background: var(--sn-color-bg);
+            color: var(--sn-color-ink);
+          }}
 
-        .sn-card {{
-          background: var(--sn-color-bg);
-          border: 1px solid var(--sn-color-border);
-          border-radius: var(--sn-radius-lg);
-          padding: var(--sn-spacing-xl);
-          box-shadow: var(--sn-shadow-soft);
-        }}
+          .sn-card {{
+            background: var(--sn-color-bg);
+            border: 1px solid var(--sn-color-border);
+            border-radius: var(--sn-radius-lg);
+            padding: var(--sn-spacing-xl);
+            box-shadow: var(--sn-shadow-soft);
+          }}
 
-        .sn-card h1,
-        .sn-card h2,
-        .sn-card h3 {{
-          margin-top: 0;
-          color: var(--sn-color-ink);
-        }}
+          .sn-card h1,
+          .sn-card h2,
+          .sn-card h3 {{
+            margin-top: 0;
+            color: var(--sn-color-ink);
+          }}
 
-        .sn-card p {{
-          margin-bottom: var(--sn-spacing-md);
-          font-size: var(--sn-type-body-size);
-          color: rgba(17, 20, 24, 0.72);
-        }}
+          .sn-card p {{
+            margin-bottom: var(--sn-spacing-md);
+            font-size: var(--sn-type-body-size);
+            color: rgba(17, 20, 24, 0.72);
+          }}
 
-        .sn-banner {{
-          border-radius: var(--sn-radius-md);
-          border: 1px solid var(--sn-color-border);
-          padding: var(--sn-spacing-lg);
-          display: flex;
-          gap: var(--sn-spacing-md);
-          align-items: flex-start;
-        }}
+          .sn-banner {{
+            border-radius: var(--sn-radius-md);
+            border: 1px solid var(--sn-color-border);
+            padding: var(--sn-spacing-lg);
+            display: flex;
+            gap: var(--sn-spacing-md);
+            align-items: flex-start;
+          }}
 
-        .sn-banner__icon {{
-          font-size: 1.25rem;
-          line-height: 1;
-        }}
+          .sn-banner__icon {{
+            font-size: 1.25rem;
+            line-height: 1;
+          }}
 
-        .sn-banner__content > h4 {{
-          margin: 0 0 var(--sn-spacing-xs) 0;
-          font-size: var(--sn-type-h2-size);
-          font-weight: var(--sn-type-h2-weight);
-          color: var(--sn-color-ink);
-        }}
+          .sn-banner__content > h4 {{
+            margin: 0 0 var(--sn-spacing-xs) 0;
+            font-size: var(--sn-type-h2-size);
+            font-weight: var(--sn-type-h2-weight);
+            color: var(--sn-color-ink);
+          }}
 
-        .sn-banner__content > p {{
-          margin: 0;
-          font-size: var(--sn-type-body-size);
-          font-weight: var(--sn-type-body-weight);
-          color: rgba(17, 20, 24, 0.72);
-        }}
+          .sn-banner__content > p {{
+            margin: 0;
+            font-size: var(--sn-type-body-size);
+            font-weight: var(--sn-type-body-weight);
+            color: rgba(17, 20, 24, 0.72);
+          }}
 
-        .sn-banner--info {{ background: var(--sn-color-info-bg); }}
-        .sn-banner--warning {{ background: var(--sn-color-warn-bg); }}
-        .sn-banner--success {{ background: var(--sn-color-success-bg); }}
+          .sn-banner--info {{ background: var(--sn-color-info-bg); }}
+          .sn-banner--warning {{ background: var(--sn-color-warn-bg); }}
+          .sn-banner--success {{ background: var(--sn-color-success-bg); }}
 
-        .sn-stepper {{
-          display: flex;
-          gap: var(--sn-spacing-sm);
-          flex-wrap: wrap;
-          list-style: none;
-          padding: 0;
-          margin: 0;
-          font-size: var(--sn-type-small-size);
-        }}
+          .sn-stepper {{
+            display: flex;
+            gap: var(--sn-spacing-sm);
+            flex-wrap: wrap;
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            font-size: var(--sn-type-small-size);
+          }}
 
-        .sn-stepper__item {{
-          display: inline-flex;
-          align-items: center;
-          gap: var(--sn-spacing-xs);
-          padding: var(--sn-spacing-xs) var(--sn-spacing-sm);
-          border-radius: var(--sn-radius-md);
-          background: var(--sn-color-bg-subtle);
-          color: var(--sn-color-ink);
-        }}
+          .sn-stepper__item {{
+            display: inline-flex;
+            align-items: center;
+            gap: var(--sn-spacing-xs);
+            padding: var(--sn-spacing-xs) var(--sn-spacing-sm);
+            border-radius: var(--sn-radius-md);
+            background: var(--sn-color-bg-subtle);
+            color: var(--sn-color-ink);
+          }}
 
-        .sn-stepper__item.is-active {{
-          background: var(--sn-color-primary);
-          color: var(--sn-color-bg);
-          font-weight: 600;
-        }}
+          .sn-stepper__item.is-active {{
+            background: var(--sn-color-primary);
+            color: var(--sn-color-bg);
+            font-weight: 600;
+          }}
 
-        .sn-stepper__item::before {{
-          content: attr(data-step);
-          display: inline-flex;
-          align-items: center;
-          justify-content: center;
-          width: 1.65rem;
-          height: 1.65rem;
-          border-radius: 999px;
-          background: rgba(43, 118, 229, 0.14);
-          color: inherit;
-          font-weight: 600;
-          font-size: 0.82rem;
-        }}
+          .sn-stepper__item::before {{
+            content: attr(data-step);
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 1.65rem;
+            height: 1.65rem;
+            border-radius: 999px;
+            background: rgba(43, 118, 229, 0.14);
+            color: inherit;
+            font-weight: 600;
+            font-size: 0.82rem;
+          }}
         </style>
         """
     )
-
-
-def _load_buttons_css() -> str:
-    """Read and cache the scoped primary/secondary/link button CSS."""
-    global _BUTTONS_CSS_CACHE
-    if _BUTTONS_CSS_CACHE is not None:
-        return _BUTTONS_CSS_CACHE
-
-    css_path = _STATIC_DIR / "buttons.css"
-    try:
-        _BUTTONS_CSS_CACHE = css_path.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        _BUTTONS_CSS_CACHE = ""
-    return _BUTTONS_CSS_CACHE
 
 
 def inject_theme() -> None:
@@ -175,19 +160,17 @@ def inject_theme() -> None:
     if st.session_state.get(_THEME_STATE_KEY):
         return
 
-    # Base token-driven theme
+    # 1) tokens
     st.markdown(_build_css(), unsafe_allow_html=True)
 
-    # Scoped button styles (primary/secondary/link)
-    buttons_css = _load_buttons_css()
-    if buttons_css:
+    # 2) buttons
+    if _BUTTONS_CSS_PATH.exists():
+        buttons_css = _BUTTONS_CSS_PATH.read_text(encoding="utf-8")
         st.markdown(f"<style>{buttons_css}</style>", unsafe_allow_html=True)
 
-    # Choice chips styling
+    # 3) chips
     if _CHIP_CSS_PATH.exists():
         chips_css = _CHIP_CSS_PATH.read_text(encoding="utf-8")
         st.markdown(f"<style>{chips_css}</style>", unsafe_allow_html=True)
 
-    # Mark injected
     st.session_state[_THEME_STATE_KEY] = True
-    st.session_state.setdefault(_BUTTONS_STATE_KEY, True)

--- a/senior_nav/static/buttons.css
+++ b/senior_nav/static/buttons.css
@@ -1,79 +1,70 @@
-.skn-scope {
-  display: block;
-  --skn-button-radius: 12px;
-  --skn-button-font-weight: 600;
-  --skn-button-padding-y: 0.75rem;
-  --skn-button-padding-x: 1.25rem;
-}
+/* senior_nav/static/buttons.css */
 
-.skn-scope [data-variant] {
-  width: 100%;
-}
-
-.skn-scope [data-variant] .stButton {
-  width: 100%;
-}
-
-.skn-scope [data-variant] .stButton > button {
-  width: 100%;
+/* Scope all changes to our pages only */
+.sn-scope .stButton > button {
+  border-radius: var(--sn-radius-md);
+  padding: calc(var(--sn-spacing-sm) + 2px) var(--sn-spacing-lg);
+  font-weight: 600;
+  line-height: 1.1;
+  box-shadow: var(--sn-shadow-soft);
+  transition: transform .02s ease-in-out, box-shadow .15s ease, background-color .15s ease, color .15s ease;
+  border: 1px solid var(--sn-color-border);
+  cursor: pointer;
   min-height: 44px;
-  border-radius: var(--skn-button-radius);
-  font-weight: var(--skn-button-font-weight);
-  padding: var(--skn-button-padding-y) var(--skn-button-padding-x);
-  border: 1px solid transparent;
-  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease,
-    box-shadow 0.15s ease;
 }
 
-.skn-scope [data-variant] .stButton > button:focus-visible {
-  outline: 3px solid var(--brand-300, #bfd0ff);
-  outline-offset: 2px;
+/* Primary */
+.sn-scope [data-variant="primary"] .stButton > button {
+  background: var(--sn-color-primary) !important;
+  color: var(--sn-color-bg) !important;
+  border-color: var(--sn-color-primary) !important;
+}
+.sn-scope [data-variant="primary"] .stButton > button:hover {
+  filter: brightness(0.95);
+}
+.sn-scope [data-variant="primary"] .stButton > button:active {
+  transform: translateY(1px);
 }
 
-.skn-scope [data-variant] .stButton > button:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
+/* Secondary */
+.sn-scope [data-variant="secondary"] .stButton > button {
+  background: var(--sn-color-bg) !important;
+  color: var(--sn-color-ink) !important;
+  border-color: var(--sn-color-border) !important;
+}
+.sn-scope [data-variant="secondary"] .stButton > button:hover {
+  background: var(--sn-color-bg-subtle) !important;
 }
 
-.skn-scope [data-variant="primary"] .stButton > button {
-  background: var(--brand-700, #1f2fab) !important;
-  color: #ffffff !important;
-  border-color: var(--brand-700, #1f2fab) !important;
-  box-shadow: 0 10px 20px rgba(31, 47, 171, 0.24);
-}
-
-.skn-scope [data-variant="primary"] .stButton > button:hover {
-  background: var(--brand-800, #17247c) !important;
-}
-
-.skn-scope [data-variant="secondary"] .stButton > button {
-  background: #ffffff !important;
-  color: var(--brand-700, #1f2fab) !important;
-  border-color: var(--brand-400, #4f6fe6) !important;
-}
-
-.skn-scope [data-variant="secondary"] .stButton > button:hover {
-  background: var(--brand-050, #eef2ff) !important;
-}
-
-/* Link-like variant: container with data-variant="link" */
-.skn-scope [data-variant="link"] .stButton > button {
+/* Link-like */
+.sn-scope [data-variant="link"] .stButton > button {
   background: transparent !important;
-  color: var(--brand-700, #1f2fab) !important;
+  color: var(--sn-color-primary) !important;
   border: 0 !important;
   box-shadow: none !important;
-  text-decoration: underline;
   padding-left: 0;
   width: auto;
   min-height: unset;
+  text-decoration: underline;
 }
-
-/* Hover/focus affordances for accessibility */
-.skn-scope [data-variant="link"] .stButton > button:hover {
+.sn-scope [data-variant="link"] .stButton > button:hover {
   text-decoration-thickness: 2px;
 }
 
-.skn-scope [data-variant="link"] .stButton > button:focus-visible {
-  outline: 3px solid var(--brand-300, #bfd0ff);
+/* Focus visibility */
+.sn-scope .stButton > button:focus-visible {
+  outline: 3px solid rgba(43,118,229,.30);
   outline-offset: 2px;
 }
+
+/* Disabled */
+.sn-scope .stButton > button:disabled,
+.sn-scope .stButton > button[disabled] {
+  opacity: .55;
+  cursor: not-allowed;
+  filter: none;
+  transform: none;
+}
+
+/* prevent auto full-width unless intended */
+.sn-scope .stButton { display: inline-block; }


### PR DESCRIPTION
## Summary
- inject the token, button, and chip CSS in a consistent order so styles load once per session
- replace the button helpers with scoped wrappers for primary, secondary, and link variants
- update the shared button stylesheet to enforce the new theming across all pages

## Testing
- Not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_b_68e189b6d9008323b67a20382bfb9116