### PR TITLE
Restore strict navigation behavior and add CI guard

### DIFF
--- a/senior_nav/components/nav.py
+++ b/senior_nav/components/nav.py
@@ -5,20 +5,9 @@ import streamlit as st
 
 
 def safe_switch_page(target: str) -> None:
-    """Attempt to navigate using ``st.switch_page`` with a graceful fallback."""
-    candidates = [target]
-    if target.startswith("ui/pages/"):
-        candidates.append(target.replace("ui/pages/", "pages/"))
-    elif target.startswith("pages/"):
-        candidates.append(target.replace("pages/", "ui/pages/"))
-
-    for candidate in candidates:
-        try:
-            st.switch_page(candidate)
-            return
-        except Exception:
-            pass
-
-    st.session_state["next_page"] = candidates[0]
-    st.error(f"Couldn't find page: {candidates[0]}. Check registered pages.")
-    st.experimental_rerun()
+    """Navigate to ``target`` and fail fast if it cannot be found."""
+    try:
+        st.switch_page(target)
+    except Exception:
+        st.error(f"Page not found: {target}")
+        raise

--- a/tests/test_no_duplicate_pages.py
+++ b/tests/test_no_duplicate_pages.py
@@ -1,0 +1,15 @@
+import os
+
+
+def test_no_duplicate_page_basenames():
+    roots = ["ui/pages"]
+    names = {}
+
+    for base in roots:
+        for dp, _, files in os.walk(base):
+            for filename in files:
+                if filename.endswith(".py"):
+                    assert (
+                        filename not in names
+                    ), f"Duplicate page filename: {filename} in {dp} and {names[filename]}"
+                    names[filename] = dp


### PR DESCRIPTION
## Summary
- restore the navigation helper to fail fast when a target page cannot be found
- add a regression test that fails when duplicate page basenames exist in ui/pages

## Testing
- pytest tests/test_no_duplicate_pages.py

------
https://chatgpt.com/codex/tasks/task_b_68e1a3a6840c832382388f4b2379857e